### PR TITLE
Fix Tailwind v4 PostCSS config (ESM + @tailwindcss/postcss)

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
-module.exports = {
+export default {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {}, // <- Remove this line if not needed
+    '@tailwindcss/postcss': {},
   }
 }


### PR DESCRIPTION
Title: Fix Tailwind CSS integration for Vite + React (Tailwind v4)

Summary
- Switch PostCSS config to ESM to match "type": "module"
- Use the official Tailwind v4 PostCSS plugin ("@tailwindcss/postcss")
- Ensure Tailwind directives in src/index.css resolve correctly under Vite

Why
The project uses Tailwind CSS v4 with the new @import-based directives in src/index.css, but PostCSS was configured using CommonJS and the legacy plugin name. In a package with "type": "module", a CommonJS postcss.config.js isn’t loaded properly, causing Tailwind styles not to compile. Using the v4 plugin and ESM config resolves this.

Changes
- postcss.config.js: convert to ESM and replace plugin list with:
  plugins: { '@tailwindcss/postcss': {} }

Impact
- Tailwind classes will now compile and appear in the app
- No behavior change to non-CSS code

Notes
- If desired, the autoprefixer devDependency can be removed in a follow-up as the v4 preset includes it internally


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/8e7472fe-d241-45f3-8591-78591db476d0/task/d14b50cf-b3fa-446b-945f-1cc3ba02bfd9))