### PR TITLE
Wallet connect system for Stacks: Zustand + neo‑brutalist UI

### DIFF
--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronDown, Loader2, LogOut, Wallet, Copy, Network, Link } from 'lucide-react';
+import useWallet, { type WalletProviderId } from '../hooks/useWallet';
+import { truncateMiddle } from '../lib/stacks';
+
+const brutal =
+  'rounded-none border-[3px] border-black shadow-[6px_6px_0_#000] active:shadow-[2px_2px_0_#000] active:translate-x-[4px] active:translate-y-[4px] transition-all';
+
+const ProviderOption = ({ name, onClick }: { name: WalletProviderId; onClick: () => void }) => (
+  <button
+    onClick={onClick}
+    className={`w-full text-left px-4 py-2 bg-white hover:bg-yellow-200 ${brutal}`}
+  >
+    <span className="font-semibold">{name}</span>
+    <span className="text-xs ml-2 opacity-70">Stacks wallet</span>
+  </button>
+);
+
+export default function WalletConnect({ className = '' }: { className?: string }) {
+  const { connect, disconnect, address, balance, providerId, isConnecting, network, switchNetwork, refresh } = useWallet();
+  const [open, setOpen] = useState(false);
+  const [showProviders, setShowProviders] = useState(false);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const label = useMemo(() => {
+    if (isConnecting) return 'Connecting…';
+    if (!address) return 'Connect Wallet';
+    const bal = balance?.stx ? `${balance.stx} STX` : '— STX';
+    return `${truncateMiddle(address)} • ${bal}`;
+  }, [isConnecting, address, balance]);
+
+  return (
+    <div className={`relative inline-block ${className}`}>
+      <button
+        onClick={() => {
+          if (!address) {
+            setShowProviders((v) => !v);
+          } else {
+            setOpen((v) => !v);
+          }
+        }}
+        disabled={isConnecting}
+        className={`flex items-center gap-2 px-4 py-3 bg-yellow-300 hover:bg-yellow-400 ${brutal}`}
+      >
+        {isConnecting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Wallet className="h-4 w-4" />
+        )}
+        <span className="text-sm font-black tracking-tight">{label}</span>
+        <ChevronDown className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      <AnimatePresence>
+        {!address && showProviders && (
+          <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 26 }}
+            className="absolute left-0 mt-3 w-[260px] z-50"
+          >
+            <div className={`p-3 bg-pink-200 ${brutal}`}>
+              <div className="text-xs font-bold mb-2">Choose a wallet</div>
+              <div className="grid gap-2">
+                {(['Hiro', 'Xverse', 'Leather'] as WalletProviderId[]).map((p) => (
+                  <ProviderOption
+                    key={p}
+                    name={p}
+                    onClick={async () => {
+                      setShowProviders(false);
+                      await connect(p).catch(() => {});
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {address && open && (
+          <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 26 }}
+            className="absolute right-0 mt-3 min-w-[260px] z-50"
+          >
+            <div className={`bg-white p-3 ${brutal}`}>
+              <div className="mb-2">
+                <div className="text-[10px] uppercase tracking-widest font-black opacity-60">Connected</div>
+                <div className="text-sm font-bold">{truncateMiddle(address)}</div>
+                <div className="text-xs">{balance?.stx ?? '—'} STX</div>
+                {providerId && <div className="text-[10px] mt-1">via {providerId}</div>}
+              </div>
+              <div className="grid gap-2">
+                <button
+                  onClick={async () => {
+                    await navigator.clipboard.writeText(address);
+                    setOpen(false);
+                  }}
+                  className={`flex items-center gap-2 px-3 py-2 bg-green-200 hover:bg-green-300 ${brutal}`}
+                >
+                  <Copy className="h-4 w-4" /> Copy address
+                </button>
+                <button
+                  onClick={async () => {
+                    await disconnect();
+                    setOpen(false);
+                  }}
+                  className={`flex items-center gap-2 px-3 py-2 bg-red-200 hover:bg-red-300 ${brutal}`}
+                >
+                  <LogOut className="h-4 w-4" /> Disconnect
+                </button>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    onClick={() => switchNetwork('testnet')}
+                    className={`flex items-center justify-center gap-2 px-3 py-2 bg-blue-200 hover:bg-blue-300 ${brutal} ${
+                      network === 'testnet' ? 'ring-2 ring-black' : ''
+                    }`}
+                  >
+                    <Network className="h-4 w-4" /> Testnet
+                  </button>
+                  <button
+                    onClick={() => switchNetwork('mainnet')}
+                    className={`flex items-center justify-center gap-2 px-3 py-2 bg-orange-200 hover:bg-orange-300 ${brutal} ${
+                      network === 'mainnet' ? 'ring-2 ring-black' : ''
+                    }`}
+                  >
+                    <Network className="h-4 w-4" /> Mainnet
+                  </button>
+                </div>
+                <a
+                  href={`https://explorer.hiro.so/${network === 'testnet' ? 'testnet/' : ''}address/${address}?chain=stacks`}
+                  target="_blank"
+                  className={`flex items-center gap-2 px-3 py-2 bg-purple-200 hover:bg-purple-300 ${brutal}`}
+                  rel="noreferrer"
+                >
+                  <Link className="h-4 w-4" /> View on explorer
+                </a>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,107 @@
+import { create } from 'zustand';
+import {
+  connect as stacksConnect,
+  disconnect as stacksDisconnect,
+  isConnected as stacksIsConnected,
+  getStxAddress,
+  getSelectedProviderId,
+  setSelectedProviderId,
+  clearSelectedProviderId,
+  getStacksProvider,
+} from '@stacks/connect';
+import { fetchStxBalance, getNetwork, type NetworkName, type StxBalance } from '../lib/stacks';
+
+export type WalletProviderId = 'Hiro' | 'Xverse' | 'Leather';
+
+export interface WalletState {
+  network: NetworkName;
+  providerId: WalletProviderId | null;
+  address: string | null;
+  balance: StxBalance | null;
+  isConnecting: boolean;
+  isFetchingBalance: boolean;
+  error: string | null;
+  connect: (provider?: WalletProviderId) => Promise<void>;
+  disconnect: () => Promise<void>;
+  switchNetwork: (network: NetworkName) => Promise<void>;
+  refresh: () => Promise<void>;
+  getAddress: () => string | null;
+}
+
+async function resolveAddress(): Promise<string | null> {
+  try {
+    const addr = await getStxAddress();
+    if (addr) return addr;
+  } catch {}
+  try {
+    const provider: any = (await getStacksProvider?.()) ?? null;
+    if (provider?.request) {
+      const res: any = await provider.request('stx_getAddresses');
+      const first = res?.addresses?.[0]?.address ?? res?.[0]?.address;
+      if (first) return first as string;
+    }
+  } catch {}
+  return null;
+}
+
+export const useWallet = create<WalletState>((set, get) => ({
+  network: 'testnet',
+  providerId: null,
+  address: null,
+  balance: null,
+  isConnecting: false,
+  isFetchingBalance: false,
+  error: null,
+  getAddress: () => get().address,
+  connect: async (provider) => {
+    set({ isConnecting: true, error: null });
+    try {
+      if (provider) setSelectedProviderId(provider);
+      getNetwork(get().network);
+      await stacksConnect({ network: get().network as any });
+      const addr = await resolveAddress();
+      const prov = (await getSelectedProviderId?.()) as WalletProviderId | null;
+      set({ address: addr, providerId: prov });
+      if (addr) {
+        const balance = await fetchStxBalance(addr, get().network);
+        set({ balance });
+      }
+    } catch (e: any) {
+      set({ error: e?.message ?? 'Failed to connect wallet' });
+    } finally {
+      set({ isConnecting: false });
+    }
+  },
+  disconnect: async () => {
+    try {
+      await stacksDisconnect();
+    } catch {}
+    try { clearSelectedProviderId?.(); } catch {}
+    set({ providerId: null, address: null, balance: null });
+  },
+  switchNetwork: async (network) => {
+    set({ network });
+    const addr = get().address;
+    if (addr) {
+      try {
+        set({ isFetchingBalance: true });
+        const balance = await fetchStxBalance(addr, network);
+        set({ balance });
+      } finally {
+        set({ isFetchingBalance: false });
+      }
+    }
+  },
+  refresh: async () => {
+    const connected = await stacksIsConnected().catch(() => false);
+    if (!connected) return;
+    const addr = await resolveAddress();
+    if (addr) {
+      set({ address: addr });
+      const balance = await fetchStxBalance(addr, get().network);
+      set({ balance });
+    }
+  },
+}));
+
+export default useWallet;

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -1,0 +1,61 @@
+import { StacksMainnet, StacksTestnet, type StacksNetwork } from '@stacks/network';
+
+export type NetworkName = 'mainnet' | 'testnet';
+
+export interface NetworkConfig {
+  name: NetworkName;
+  network: StacksNetwork;
+  apiBaseUrl: string;
+  explorerBaseUrl: string;
+}
+
+export const NETWORKS: Record<NetworkName, NetworkConfig> = {
+  mainnet: {
+    name: 'mainnet',
+    network: new StacksMainnet(),
+    apiBaseUrl: 'https://api.hiro.so',
+    explorerBaseUrl: 'https://explorer.hiro.so',
+  },
+  testnet: {
+    name: 'testnet',
+    network: new StacksTestnet(),
+    apiBaseUrl: 'https://api.testnet.hiro.so',
+    explorerBaseUrl: 'https://explorer.hiro.so/testnet',
+  },
+};
+
+export const getNetwork = (name: NetworkName): StacksNetwork => NETWORKS[name].network;
+export const getApiBaseUrl = (name: NetworkName): string => NETWORKS[name].apiBaseUrl;
+
+export const getExplorerAddressUrl = (name: NetworkName, address: string) =>
+  `${NETWORKS[name].explorerBaseUrl}/address/${address}?chain=stacks`;
+
+export const MICROSTX = 1_000_000n;
+
+export const microToStx = (micro: bigint | number | string): string => {
+  const value = typeof micro === 'bigint' ? micro : BigInt(micro);
+  const whole = value / MICROSTX;
+  const frac = value % MICROSTX;
+
+  const fracStr = frac.toString().padStart(6, '0').replace(/0+$/, '');
+  return fracStr.length ? `${whole.toString()}.${fracStr}` : whole.toString();
+};
+
+export interface StxBalance {
+  micro: string;
+  stx: string;
+}
+
+export async function fetchStxBalance(address: string, network: NetworkName): Promise<StxBalance> {
+  const url = `${getApiBaseUrl(network)}/extended/v1/address/${address}/balances`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch balance (${res.status})`);
+  const json: any = await res.json();
+  const micro: string = json?.stx?.balance ?? '0';
+  return { micro, stx: microToStx(micro) };
+}
+
+export const truncateMiddle = (str: string, front = 6, back = 4) =>
+  str.length <= front + back + 3
+    ? str
+    : `${str.slice(0, front)}…${str.slice(-back)}`;


### PR DESCRIPTION
## Summary
Add a complete Stacks wallet connection system powered by `@stacks/connect`, Zustand, TailwindCSS, and framer-motion. This introduces a polished neo‑brutalist WalletConnect component with multi‑wallet support and live balance display.

## What’s included
- Network configuration (testnet + mainnet) and helpers
  - `src/lib/stacks.ts` – `NETWORKS`, `getNetwork`, `fetchStxBalance`, `microToStx`, `truncateMiddle`
- Zustand store + React hook for wallet state
  - `src/hooks/useWallet.ts` – connect/disconnect, get current address, network switching, balance fetch, refresh
  - Provider selection compatible with Hiro, Xverse, Leather via `@stacks/connect`
- Beautiful UI component
  - `src/components/WalletConnect.tsx` – animated neo‑brutalist button with provider picker, connected dropdown, copy address, explorer link, and network toggle

## Why
- Establishes a standard, extensible wallet layer for Stacks apps
- Improves onboarding with a clear, delightful connect flow
- Centralizes wallet state and reduces duplication across pages

## How to use
- Import and render the component where needed:
  ```tsx
  import WalletConnect from './src/components/WalletConnect';
  
  export default function Header() {
    return (
      <div className="p-4">
        <WalletConnect />
      </div>
    );
  }
  ```
- Default network is testnet; use the dropdown to switch to mainnet.

## Follow‑ups (optional)
- Add message signing, STX transfer, and contract call helpers to the hook
- Persist selected provider/network and auto‑reconnect on load

## Screens/UX
- Neo‑brutalist styling with bold borders, offset shadows, and spring animations for a tactile feel


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/8e7472fe-d241-45f3-8591-78591db476d0/task/c47a1069-360d-4f8e-8309-eb4e40da3b77))