### PR TITLE
Fix @stacks/network import error (white screen issue)

### DIFF
--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -1,4 +1,4 @@
-import { StacksMainnet, StacksTestnet, type StacksNetwork } from '@stacks/network';
+import { STACKS_MAINNET, STACKS_TESTNET, type StacksNetwork } from '@stacks/network';
 
 export type NetworkName = 'mainnet' | 'testnet';
 
@@ -12,13 +12,13 @@ export interface NetworkConfig {
 export const NETWORKS: Record<NetworkName, NetworkConfig> = {
   mainnet: {
     name: 'mainnet',
-    network: new StacksMainnet(),
+    network: STACKS_MAINNET,
     apiBaseUrl: 'https://api.hiro.so',
     explorerBaseUrl: 'https://explorer.hiro.so',
   },
   testnet: {
     name: 'testnet',
-    network: new StacksTestnet(),
+    network: STACKS_TESTNET,
     apiBaseUrl: 'https://api.testnet.hiro.so',
     explorerBaseUrl: 'https://explorer.hiro.so/testnet',
   },


### PR DESCRIPTION
## Summary
Fix critical import error preventing the wallet connection system from loading. The app was showing a white screen with console error about missing `StacksMainnet` export.

## What's Fixed

### 🐛 Import Error (`src/lib/stacks.ts`)
Changed imports to match `@stacks/network` v7.2.0 API:

**Before (broken):**
```typescript
import { StacksMainnet, StacksTestnet } from '@stacks/network';

network: new StacksMainnet(),  // ❌ These classes don't exist
network: new StacksTestnet(),
```

**After (working):**
```typescript
import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';

network: STACKS_MAINNET,  // ✅ Use exported constants
network: STACKS_TESTNET,
```

## Why
The `@stacks/network` package changed its API in v7.x from class-based constructors to exported constant objects. Using the old API caused:
- **Error**: `The requested module does not provide an export named 'StacksMainnet'`
- **Result**: White screen, app unable to load

## Testing
1. Run `npm run dev`
2. Open http://localhost:5173/
3. App loads successfully (no white screen)
4. "Connect Wallet" button is visible
5. No console errors

## Impact
- **Critical fix** - unblocks all wallet functionality
- No breaking changes to the public API
- Existing wallet connections work as expected


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/8e7472fe-d241-45f3-8591-78591db476d0/task/c47a1069-360d-4f8e-8309-eb4e40da3b77))