### PR TITLE
Enhance wallet logging and add mainnet fallback

### DIFF
--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -29,17 +29,29 @@ export interface WalletState {
 function getAddressFromStorage(network: NetworkName): string | null {
   try {
     const storage = getLocalStorage();
-    console.log('[useWallet] localStorage:', storage);
+    console.log('[useWallet] Full localStorage:', JSON.stringify(storage, null, 2));
+    
     if (!storage?.addresses) {
       console.warn('[useWallet] No addresses in storage');
       return null;
     }
+    
+    console.log('[useWallet] Available networks:', Object.keys(storage.addresses));
+    
     const networkAddresses = storage.addresses[network];
     console.log(`[useWallet] ${network} addresses:`, networkAddresses);
+    
     if (!networkAddresses || networkAddresses.length === 0) {
       console.warn(`[useWallet] No ${network} address found`);
+      console.log('[useWallet] Trying mainnet instead...');
+      const mainnetAddresses = storage.addresses['mainnet'];
+      if (mainnetAddresses && mainnetAddresses.length > 0) {
+        console.log('[useWallet] Found mainnet address:', mainnetAddresses[0]);
+        return mainnetAddresses[0];
+      }
       return null;
     }
+    
     return networkAddresses[0];
   } catch (e) {
     console.error('[useWallet] Error reading storage:', e);


### PR DESCRIPTION
## Summary
Enhance wallet debugging to show full localStorage structure and identify why testnet addresses are missing. Adds fallback to mainnet addresses if testnet not available.

## Issue Identified
From console logs, we discovered:
```
[useWallet] testnet addresses: undefined
[useWallet] No testnet address found
```

Connection succeeds, but addresses aren't stored under `testnet` network key.

## Solution

### Enhanced Logging
- **Show full localStorage JSON** with proper formatting
- **Log available network keys** to see what the wallet actually stores
- Helps identify if addresses are under different network names

### Mainnet Fallback
- If testnet addresses not found, automatically try mainnet
- Prevents connection from failing when wallet only stores mainnet
- Logs when fallback is used

## Code Changes

**Before:**
```typescript
const networkAddresses = storage.addresses[network];
if (!networkAddresses || networkAddresses.length === 0) {
  console.warn(`No ${network} address found`);
  return null;
}
```

**After:**
```typescript
console.log('Full localStorage:', JSON.stringify(storage, null, 2));
console.log('Available networks:', Object.keys(storage.addresses));

const networkAddresses = storage.addresses[network];
if (!networkAddresses || networkAddresses.length === 0) {
  console.log('Trying mainnet instead...');
  const mainnetAddresses = storage.addresses['mainnet'];
  if (mainnetAddresses && mainnetAddresses.length > 0) {
    console.log('Found mainnet address:', mainnetAddresses[0]);
    return mainnetAddresses[0];
  }
  return null;
}
```

## Expected Behavior

### Console Output
```
[useWallet] Full localStorage: {
  "addresses": {
    "mainnet": ["SP..."],
    "testnet": ["ST..."]  // or missing
  }
}
[useWallet] Available networks: ["mainnet", "testnet"]
[useWallet] testnet addresses: undefined
[useWallet] Trying mainnet instead...
[useWallet] Found mainnet address: SP...
```

### User Impact
- If wallet stores mainnet addresses only → connection works with mainnet address
- If wallet stores both networks → uses correct network
- Detailed logs help diagnose any remaining issues

## Testing

1. Hard refresh browser
2. Open console
3. Connect wallet
4. Check logs for:
   - Full localStorage structure
   - Available networks list
   - Whether fallback was used

## Follow-up

Once we see the localStorage structure, we can:
- Properly handle network-specific addresses
- Add network switching that respects stored addresses
- Remove fallback if not needed
- Clean up debug logs for production


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/8e7472fe-d241-45f3-8591-78591db476d0/task/c47a1069-360d-4f8e-8309-eb4e40da3b77))