### PR TITLE
Fix STX address resolution for Stacks Connect v8

### DIFF
--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -7,7 +7,7 @@ import {
   setSelectedProviderId,
   clearSelectedProviderId,
 } from '@stacks/connect';
-import { fetchStxBalance, getNetwork, type NetworkName, type StxBalance } from '../lib/stacks';
+import { fetchStxBalance, type NetworkName, type StxBalance } from '../lib/stacks';
 
 export type WalletProviderId = 'LeatherProvider' | 'XverseProviders.BitcoinProvider' | 'HiroWalletProvider';
 
@@ -26,37 +26,126 @@ export interface WalletState {
   getAddress: () => string | null;
 }
 
+const STACKS_ADDR_REGEX = /^(SP|ST)[A-Z0-9]{20,}$/i;
+
+function pickAddressForNetwork(addresses: string[], network: NetworkName): string | null {
+  const norm = addresses.filter((a) => STACKS_ADDR_REGEX.test(a));
+  if (!norm.length) return null;
+  const preferPrefix = network === 'testnet' ? 'ST' : 'SP';
+  const preferred = norm.find((a) => a.toUpperCase().startsWith(preferPrefix));
+  return preferred ?? norm[0];
+}
+
+function collectAddressesFromStorage(storage: any): string[] {
+  const out: string[] = [];
+  try {
+    if (!storage) return out;
+    if (storage.addresses) {
+      const { addresses } = storage;
+      Object.keys(addresses).forEach((k) => {
+        const arr = addresses[k];
+        if (Array.isArray(arr)) out.push(...arr);
+      });
+    }
+    if (storage.stxAddresses) {
+      const { stxAddresses } = storage;
+      Object.keys(stxAddresses).forEach((k) => {
+        const v = stxAddresses[k];
+        if (typeof v === 'string') out.push(v);
+        if (Array.isArray(v)) out.push(...v);
+      });
+    }
+    if (Array.isArray(storage.accounts)) {
+      for (const acc of storage.accounts) {
+        if (typeof acc?.stxAddress === 'string') out.push(acc.stxAddress);
+        if (typeof acc?.address === 'string') out.push(acc.address);
+        if (acc?.addresses) {
+          const a = acc.addresses;
+          if (typeof a?.mainnet === 'string') out.push(a.mainnet);
+          if (typeof a?.testnet === 'string') out.push(a.testnet);
+          if (Array.isArray(a)) out.push(...a);
+        }
+      }
+    }
+    if (storage?.accounts?.stx) {
+      const s = storage.accounts.stx;
+      if (typeof s?.mainnet === 'string') out.push(s.mainnet);
+      if (typeof s?.testnet === 'string') out.push(s.testnet);
+    }
+  } catch {}
+  return out;
+}
+
 function getAddressFromStorage(network: NetworkName): string | null {
   try {
     const storage = getLocalStorage();
-    console.log('[useWallet] Full localStorage:', JSON.stringify(storage, null, 2));
-    
-    if (!storage?.addresses) {
-      console.warn('[useWallet] No addresses in storage');
+    console.log('[useWallet] Local storage snapshot:', JSON.stringify(storage, null, 2));
+    const candidates = collectAddressesFromStorage(storage);
+    if (!candidates.length) {
+      console.warn('[useWallet] No STX addresses found in storage');
       return null;
     }
-    
-    console.log('[useWallet] Available networks:', Object.keys(storage.addresses));
-    
-    const networkAddresses = storage.addresses[network];
-    console.log(`[useWallet] ${network} addresses:`, networkAddresses);
-    
-    if (!networkAddresses || networkAddresses.length === 0) {
-      console.warn(`[useWallet] No ${network} address found`);
-      console.log('[useWallet] Trying mainnet instead...');
-      const mainnetAddresses = storage.addresses['mainnet'];
-      if (mainnetAddresses && mainnetAddresses.length > 0) {
-        console.log('[useWallet] Found mainnet address:', mainnetAddresses[0]);
-        return mainnetAddresses[0];
-      }
-      return null;
+    const selected = pickAddressForNetwork(candidates, network);
+    if (!selected) {
+      console.warn('[useWallet] No address matched expected network, using first available');
+      return candidates[0] ?? null;
     }
-    
-    return networkAddresses[0];
+    return selected;
   } catch (e) {
     console.error('[useWallet] Error reading storage:', e);
     return null;
   }
+}
+
+async function getAddressFromProvider(network: NetworkName): Promise<string | null> {
+  try {
+    const w: any = globalThis as any;
+    const providers: any[] = [
+      w?.StacksProvider,
+      w?.HiroWalletProvider,
+      w?.LeatherProvider,
+      w?.XverseProviders?.BitcoinProvider,
+    ].filter(Boolean);
+
+    for (const p of providers) {
+      try {
+        if (typeof p?.getAddresses === 'function') {
+          const res = await p.getAddresses();
+          const all = collectAddressesFromStorage(res) || [];
+          const chosen = pickAddressForNetwork(all, network);
+          if (chosen) return chosen;
+        }
+      } catch {}
+      try {
+        const possible: string[] = [];
+        if (typeof p?.selectedAddress === 'string') possible.push(p.selectedAddress);
+        if (typeof p?.stxAddress === 'string') possible.push(p.stxAddress);
+        if (typeof p?.address === 'string') possible.push(p.address);
+        if (p?.selectedAccount?.addresses) {
+          const a = p.selectedAccount.addresses;
+          if (typeof a?.mainnet === 'string') possible.push(a.mainnet);
+          if (typeof a?.testnet === 'string') possible.push(a.testnet);
+        }
+        const chosen = pickAddressForNetwork(possible, network);
+        if (chosen) return chosen;
+      } catch {}
+      try {
+        if (typeof p?.request === 'function') {
+          // Try a couple of common method names defensively
+          const methods = ['stx_getAddresses', 'getAddresses'];
+          for (const m of methods) {
+            try {
+              const res = await p.request({ method: m });
+              const all = collectAddressesFromStorage(res) || [];
+              const chosen = pickAddressForNetwork(all, network);
+              if (chosen) return chosen;
+            } catch {}
+          }
+        }
+      } catch {}
+    }
+  } catch {}
+  return null;
 }
 
 export const useWallet = create<WalletState>((set, get) => ({
@@ -72,24 +161,28 @@ export const useWallet = create<WalletState>((set, get) => ({
     set({ isConnecting: true, error: null });
     try {
       console.log('[useWallet] Starting connection with provider:', provider);
-      
+
       if (provider) {
         console.log('[useWallet] Setting provider ID:', provider);
         setSelectedProviderId(provider);
       }
-      
+
       console.log('[useWallet] Calling stacksConnect()...');
       const result = await stacksConnect();
       console.log('[useWallet] stacksConnect result:', result);
-      
-      const addr = getAddressFromStorage(get().network);
-      const prov = getSelectedProviderId() as WalletProviderId | null;
-      
-      console.log('[useWallet] Retrieved address:', addr);
-      console.log('[useWallet] Retrieved provider:', prov);
-      
+
+      let addr = getAddressFromStorage(get().network);
+      if (!addr) {
+        addr = await getAddressFromProvider(get().network);
+      }
+
+      const prov = (getSelectedProviderId() as WalletProviderId | null) ?? provider ?? null;
+
+      console.log('[useWallet] Resolved address:', addr);
+      console.log('[useWallet] Resolved provider:', prov);
+
       set({ address: addr, providerId: prov });
-      
+
       if (addr) {
         console.log('[useWallet] Fetching balance...');
         const balance = await fetchStxBalance(addr, get().network);
@@ -117,9 +210,9 @@ export const useWallet = create<WalletState>((set, get) => ({
   },
   switchNetwork: async (network) => {
     set({ network });
-    const addr = getAddressFromStorage(network);
+    const addr = getAddressFromStorage(network) ?? (await getAddressFromProvider(network));
     set({ address: addr });
-    
+
     if (addr) {
       try {
         set({ isFetchingBalance: true });
@@ -133,7 +226,7 @@ export const useWallet = create<WalletState>((set, get) => ({
     }
   },
   refresh: async () => {
-    const addr = getAddressFromStorage(get().network);
+    const addr = getAddressFromStorage(get().network) ?? (await getAddressFromProvider(get().network));
     if (addr) {
       set({ address: addr });
       try {


### PR DESCRIPTION
## Summary

Fix STX address resolution with @stacks/connect v8 to prevent the "Connected but no address found" state after a successful wallet connection.

## Why

After upgrading to @stacks/connect v8, the structure of wallet state surfaced by the library and/or providers is not guaranteed to include `storage.addresses`. Our connect flow relied solely on `getLocalStorage().addresses[network][0]`. When that shape was absent (common with v8 and some providers), we showed:

> Connected but no address found. Try disconnecting and reconnecting.

This was confusing because the wallet did connect.

## What changed

- Implemented robust address resolution that:
  - Parses multiple potential shapes from `getLocalStorage()` (e.g., `addresses`, `stxAddresses`, `accounts`, nested `addresses` objects).
  - Falls back to querying the active provider (StacksProvider/Hiro/Leather/Xverse) via `getAddresses()` or `request()` when available.
  - Selects an address appropriate for the current network (`SP*` for mainnet, `ST*` for testnet) with a safe fallback.
- Applied the same logic for `connect`, `switchNetwork`, and `refresh` flows so address state remains consistent.
- Preserved existing public API of the `useWallet` hook.

## Impact

- Users should no longer see the erroneous "Connected but no address found" error after connecting.
- Works across multiple providers and storage variants without depending on a single internal shape.
- No breaking changes to components consuming `useWallet`.

## Testing notes

- Connect using Hiro, Leather, and Xverse on testnet and mainnet.
- Verify the address and STX balance render correctly.
- Toggle networks and ensure the address/balance update.
- Disconnect and reconnect; the address should resolve consistently.

## Files

- src/hooks/useWallet.ts — main fix (robust address resolution + fallbacks)

---

If you want me to expand coverage (unit tests or provider mocks), let me know and I can follow up in a separate PR.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/d0cfbf19-1464-4f41-ad4d-70ad1fe580a6/task/02475219-f0e0-4b23-ab01-ca9473763120))