### PR TITLE
Add neo‑brutalist Home page and router with /puzzle/:id

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,89 +1,19 @@
-import WalletConnect from './components/WalletConnect';
-import useWallet from './hooks/useWallet';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import PuzzlePage from './pages/Puzzle';
 
 const queryClient = new QueryClient();
 
 export default function App() {
-  const { address, balance, network, providerId, error } = useWallet();
-
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="min-h-screen bg-gradient-to-br from-pink-100 via-yellow-100 to-blue-100 p-8">
-        <div className="max-w-4xl mx-auto">
-          <header className="flex items-center justify-between mb-12">
-            <h1 className="text-4xl font-black tracking-tight">
-              🔥 Stackmate
-            </h1>
-            <WalletConnect />
-          </header>
-
-          <main className="rounded-none border-[3px] border-black shadow-[8px_8px_0_#000] bg-white p-8">
-            <h2 className="text-2xl font-black mb-6">Wallet Status</h2>
-            
-            {error && (
-              <div className="mb-6 bg-red-100 p-4 rounded-none border-2 border-red-600">
-                <div className="text-xs font-bold uppercase tracking-wider text-red-800">Error</div>
-                <div className="text-sm text-red-900 mt-1">{error}</div>
-              </div>
-            )}
-            
-            {address ? (
-              <div className="space-y-4">
-                <div className="bg-green-100 p-4 rounded-none border-2 border-black">
-                  <div className="text-xs font-bold uppercase tracking-wider opacity-60">Connected</div>
-                  <div className="font-mono text-sm mt-1">{address}</div>
-                </div>
-
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="bg-yellow-100 p-4 rounded-none border-2 border-black">
-                    <div className="text-xs font-bold uppercase">Balance</div>
-                    <div className="text-2xl font-black">{balance?.stx ?? '—'}</div>
-                    <div className="text-xs opacity-60">STX</div>
-                  </div>
-
-                  <div className="bg-blue-100 p-4 rounded-none border-2 border-black">
-                    <div className="text-xs font-bold uppercase">Network</div>
-                    <div className="text-2xl font-black">{network}</div>
-                  </div>
-
-                  <div className="bg-purple-100 p-4 rounded-none border-2 border-black">
-                    <div className="text-xs font-bold uppercase">Wallet</div>
-                    <div className="text-2xl font-black">{providerId ?? '—'}</div>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="bg-orange-100 p-6 rounded-none border-2 border-black text-center">
-                <div className="text-lg font-bold mb-2">No wallet connected</div>
-                <div className="text-sm opacity-70">Click "Connect Wallet" above to get started</div>
-              </div>
-            )}
-
-            <div className="mt-8 pt-8 border-t-2 border-black">
-              <h3 className="text-lg font-black mb-4">Testing Instructions</h3>
-              <ol className="space-y-2 text-sm">
-                <li className="flex gap-2">
-                  <span className="font-black">1.</span>
-                  <span>Install a Stacks wallet extension (Hiro, Xverse, or Leather)</span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="font-black">2.</span>
-                  <span>Click "Connect Wallet" and choose your wallet</span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="font-black">3.</span>
-                  <span>Approve the connection in your wallet popup</span>
-                </li>
-                <li className="flex gap-2">
-                  <span className="font-black">4.</span>
-                  <span>Your address and balance should appear above</span>
-                </li>
-              </ol>
-            </div>
-          </main>
-        </div>
-      </div>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/puzzle/:id" element={<PuzzlePage />} />
+        </Routes>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,350 @@
+import { useMemo } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import WalletConnect from '../components/WalletConnect';
+import useWallet from '../hooks/useWallet';
+import { useActivePuzzles } from '../hooks/useBlockchain';
+import { getPuzzleInfo, getLeaderboard, type LeaderboardEntry, type PuzzleInfo } from '../lib/contracts';
+import { getApiBaseUrl, microToStx, type NetworkName } from '../lib/stacks';
+import { Trophy, Zap, Clock, Users, Coins, Sword, Crown, Target, Sparkles } from 'lucide-react';
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
+
+function useStacksHeight(network: NetworkName) {
+  return useQuery<number>({
+    queryKey: ['stacks-height', network],
+    queryFn: async () => {
+      const res = await fetch(`${getApiBaseUrl(network)}/v2/info`);
+      const j: any = await res.json();
+      const h = Number(j?.stacks_tip_height ?? j?.stacks_tip?.height ?? j?.burn_block_height ?? 0);
+      return Number.isFinite(h) ? h : 0;
+    },
+    refetchInterval: 10000,
+    refetchOnWindowFocus: false,
+    staleTime: 8000,
+  });
+}
+
+function formatTimeSeconds(total: number | bigint) {
+  const n = typeof total === 'bigint' ? Number(total) : total;
+  const m = Math.floor(n / 60);
+  const s = n % 60;
+  const mm = m < 10 ? `0${m}` : `${m}`;
+  const ss = s < 10 ? `0${s}` : `${s}`;
+  return `${mm}:${ss}`;
+}
+
+function blocksToEta(blocksLeft: number) {
+  const sec = Math.max(0, Math.floor(blocksLeft * 600));
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  const parts = [h ? `${h}h` : null, m ? `${m}m` : null, (!h && !m) ? `${s}s` : null].filter(Boolean);
+  return parts.join(' ');
+}
+
+function Piece({ glyph, x, y, delay = 0 }: { glyph: string; x: string; y: string; delay?: number }) {
+  return (
+    <motion.span
+      className="absolute select-none pointer-events-none text-black/40 dark:text-white/20"
+      style={{ left: x, top: y }}
+      initial={{ y: -10, opacity: 0 }}
+      animate={{ y: [0, -6, 0, 6, 0], opacity: 1 }}
+      transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut', delay }}
+    >
+      <span className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl">{glyph}</span>
+    </motion.span>
+  );
+}
+
+function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-5`}>{children}</div>
+  );
+}
+
+function Stat({ icon, label, value, accent }: { icon: React.ReactNode; label: string; value: string; accent: string }) {
+  return (
+    <div className={`${brutal} ${accent} p-4 text-black dark:text-zinc-900`}> 
+      <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider">{icon}<span>{label}</span></div>
+      <div className="text-2xl font-black mt-1">{value}</div>
+    </div>
+  );
+}
+
+export default function Home() {
+  const { network, getAddress } = useWallet();
+  const address = getAddress() || '';
+
+  const { data: activeIds = [], isLoading: activeLoading } = useActivePuzzles();
+  const heightQ = useStacksHeight(network);
+
+  const infoQueries = useQueries({
+    queries: (activeIds || []).map((id) => ({
+      queryKey: ['puzzle-info', network, String(id)],
+      queryFn: () => getPuzzleInfo({ puzzleId: id, network }),
+      enabled: activeIds.length > 0,
+      refetchInterval: 15000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const infos = useMemo(() => infoQueries.map((q) => q.data).filter(Boolean) as PuzzleInfo[], [infoQueries]);
+
+  const pairs = useMemo(() => {
+    return (activeIds || []).map((id, i) => ({ id, info: infoQueries[i]?.data as PuzzleInfo | undefined }))
+      .filter((p) => p.info) as Array<{ id: number; info: PuzzleInfo }>;
+  }, [activeIds, infoQueries]);
+
+  const byDifficulty = useMemo(() => {
+    const pick = (d: string) => pairs.find((p) => (p.info.difficulty || '').toLowerCase() === d) || null;
+    return {
+      beginner: pick('beginner'),
+      intermediate: pick('intermediate'),
+      expert: pick('expert'),
+    } as Record<'beginner'|'intermediate'|'expert', { id: number; info: PuzzleInfo } | null>;
+  }, [pairs]);
+
+  const displayList = useMemo(() => {
+    const order: Array<{ key: 'beginner'|'intermediate'|'expert'; label: string; fallbackFee: string; color: string }>= [
+      { key: 'beginner', label: 'Beginner', fallbackFee: '0.5', color: 'bg-yellow-300' },
+      { key: 'intermediate', label: 'Intermediate', fallbackFee: '2', color: 'bg-blue-300' },
+      { key: 'expert', label: 'Expert', fallbackFee: '5', color: 'bg-pink-300' },
+    ];
+    return order.map((o) => {
+      const pair = (byDifficulty as any)[o.key] as { id: number; info: PuzzleInfo } | null;
+      return {
+        key: o.key,
+        label: o.label,
+        id: pair?.id,
+        info: pair?.info ?? null,
+        fallbackFee: o.fallbackFee,
+        color: o.color,
+      };
+    });
+  }, [byDifficulty]);
+
+  const leaderboardsQueries = useQueries({
+    queries: displayList.map((d) => ({
+      queryKey: ['leaderboard', network, d.label, String(d.id ?? '0')],
+      queryFn: () => (d.id ? getLeaderboard({ puzzleId: d.id, network }) : Promise.resolve([] as LeaderboardEntry[])),
+      enabled: Boolean(d.id),
+      refetchInterval: 20000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const leaders = leaderboardsQueries.map((q) => (q.data || []) as LeaderboardEntry[]);
+
+  const stats = useMemo(() => {
+    const totalActivePrize = infos.reduce((acc, p) => acc + Number(p.prizePool), 0);
+    const totalPlayers = infos.reduce((acc, p) => acc + Number(p.entryCount), 0);
+    const correct = leaders.flat().filter((x) => x.isCorrect).length;
+    return {
+      totalSolved: correct,
+      totalPrizeStx: microToStx(BigInt(totalActivePrize)),
+      activePlayers: totalPlayers,
+    };
+  }, [infos, leaders]);
+
+  const bgGrad = 'from-yellow-200 via-rose-200 to-blue-200 dark:from-zinc-900 dark:via-zinc-800 dark:to-zinc-900';
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${bgGrad} text-black dark:text-white relative overflow-hidden`}> 
+      <div className="absolute inset-0 pointer-events-none">
+        <Piece glyph="♔" x="5%" y="10%" />
+        <Piece glyph="♕" x="80%" y="15%" delay={1} />
+        <Piece glyph="♖" x="15%" y="70%" delay={2} />
+        <Piece glyph="♘" x="65%" y="65%" delay={3} />
+        <Piece glyph="♟" x="40%" y="30%" delay={1.5} />
+      </div>
+
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-14 lg:py-20">
+        <header className="flex items-center justify-between mb-8 sm:mb-12">
+          <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur px-4 py-2 text-xl font-black tracking-tight`}>Stackmate</div>
+          <WalletConnect />
+        </header>
+
+        <section className="mb-14 sm:mb-20">
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+            className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-6 sm:p-10 relative overflow-hidden`}
+          >
+            <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+              <div>
+                <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black leading-[1.05]">
+                  Solve Chess Puzzles, Win STX
+                </h1>
+                <p className="mt-4 text-base sm:text-lg opacity-80">
+                  Fastest solver takes the entire prize pool
+                </p>
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <a href="#difficulties" className={`px-5 py-3 bg-yellow-300 hover:bg-yellow-400 ${brutal} inline-flex items-center gap-2`}>
+                    <Zap className="h-4 w-4" /> Play Now
+                  </a>
+                  <a href="#how" className={`px-5 py-3 bg-blue-300 hover:bg-blue-400 ${brutal} inline-flex items-center gap-2`}>
+                    <Target className="h-4 w-4" /> How it works
+                  </a>
+                </div>
+              </div>
+              <div className="relative min-h-[240px] lg:min-h-[320px]">
+                <motion.div
+                  initial={{ rotate: -2, scale: 0.95 }}
+                  animate={{ rotate: 0, scale: 1 }}
+                  transition={{ type: 'spring', stiffness: 180, damping: 16 }}
+                  className={`${brutal} bg-gradient-to-br from-white/80 to-yellow-100/70 dark:from-zinc-800/80 dark:to-zinc-700/70 backdrop-blur p-6`}
+                >
+                  <div className="grid grid-cols-3 gap-2 text-4xl sm:text-5xl lg:text-6xl">
+                    <div className="text-center">♜</div>
+                    <div className="text-center">♞</div>
+                    <div className="text-center">♝</div>
+                    <div className="text-center">♛</div>
+                    <div className="text-center">♚</div>
+                    <div className="text-center">♟</div>
+                  </div>
+                </motion.div>
+                <motion.div
+                  className="absolute -inset-3 -z-10"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.8 }}
+                  style={{ background: 'repeating-linear-gradient(45deg, rgba(0,0,0,0.06) 0, rgba(0,0,0,0.06) 10px, transparent 10px, transparent 20px)' }}
+                />
+              </div>
+            </div>
+          </motion.div>
+        </section>
+
+        <section id="difficulties" className="mb-16 sm:mb-20">
+          <div className="flex items-center gap-2 mb-4">
+            <Sparkles className="h-5 w-5" />
+            <h2 className="text-2xl sm:text-3xl font-black">Choose Your Challenge</h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            {displayList.map((d, idx) => {
+              const info = d.info as PuzzleInfo | null;
+              const lb = leaders[idx] || [];
+              const best = lb.filter((x) => x.player?.toLowerCase() === address.toLowerCase()).map((x) => x.solveTime).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))[0];
+              const entryFee = info ? microToStx(info.stakeAmount) : d.fallbackFee;
+              const prize = info ? microToStx(info.prizePool) : '0';
+              const players = info ? Number(info.entryCount) : 0;
+              const height = heightQ.data || 0;
+              const deadline = info ? Number(info.deadline) : 0;
+              const blocksLeft = Math.max(0, deadline - height);
+              const eta = blocksLeft > 0 ? `${blocksLeft} blocks • ≈ ${blocksToEta(blocksLeft)}` : 'Ended or pending';
+              const btnHref = d.id ? `/?puzzle=${String(d.id)}` : '#';
+              return (
+                <motion.div
+                  key={d.label}
+                  initial={{ opacity: 0, y: 10 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ type: 'spring', stiffness: 300, damping: 22, delay: idx * 0.05 }}
+                  className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-5 flex flex-col`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="text-xl font-black">{d.label}</div>
+                    <div className={`${brutal} ${d.color} px-2 py-1 text-xs font-black`}>Entry {entryFee} STX</div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3 mt-4 text-sm">
+                    <div className={`${brutal} bg-green-200 p-3 text-black`}>
+                      <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Coins className="h-3 w-3" /> Prize Pool</div>
+                      <div className="text-lg font-black">{prize} STX</div>
+                    </div>
+                    <div className={`${brutal} bg-blue-200 p-3 text-black`}>
+                      <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Users className="h-3 w-3" /> Players</div>
+                      <div className="text-lg font-black">{players}</div>
+                    </div>
+                    <div className={`${brutal} bg-yellow-200 p-3 text-black`}>
+                      <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Clock className="h-3 w-3" /> Your Best</div>
+                      <div className="text-lg font-black">{best ? formatTimeSeconds(best) : '—'}</div>
+                    </div>
+                    <div className={`${brutal} bg-pink-200 p-3 text-black`}>
+                      <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Trophy className="h-3 w-3" /> Deadline</div>
+                      <div className="text-xs font-black">{eta}</div>
+                    </div>
+                  </div>
+                  <a href={btnHref} className={`mt-4 px-4 py-3 bg-black text-white hover:bg-zinc-800 ${brutal} inline-flex items-center justify-center gap-2`}>
+                    <Sword className="h-4 w-4" /> Enter Puzzle
+                  </a>
+                </motion.div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section id="how" className="mb-16 sm:mb-20">
+          <div className="flex items-center gap-2 mb-4">
+            <Target className="h-5 w-5" />
+            <h2 className="text-2xl sm:text-3xl font-black">How It Works</h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            <Card>
+              <div className="flex items-center gap-3">
+                <Zap className="h-5 w-5" />
+                <div className="text-lg font-black">Enter</div>
+              </div>
+              <p className="text-sm mt-2 opacity-80">Stake the entry fee to join a live puzzle. Every entry increases the prize pool.</p>
+            </Card>
+            <Card>
+              <div className="flex items-center gap-3">
+                <Clock className="h-5 w-5" />
+                <div className="text-lg font-black">Solve</div>
+              </div>
+              <p className="text-sm mt-2 opacity-80">Recreate the exact move sequence faster than everyone else. Hints add time penalties.</p>
+            </Card>
+            <Card>
+              <div className="flex items-center gap-3">
+                <Crown className="h-5 w-5" />
+                <div className="text-lg font-black">Win</div>
+              </div>
+              <p className="text-sm mt-2 opacity-80">After the deadline, the fastest correct solver takes it all. Funds settle on-chain.</p>
+            </Card>
+          </div>
+        </section>
+
+        <section className="mb-20">
+          <div className="flex items-center gap-2 mb-4">
+            <Trophy className="h-5 w-5" />
+            <h2 className="text-2xl sm:text-3xl font-black">Stats</h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-4">
+            <Stat icon={<Clock className="h-4 w-4" />} label="Total Puzzles Solved" value={String(stats.totalSolved)} accent="bg-yellow-300" />
+            <Stat icon={<Coins className="h-4 w-4" />} label="Total STX in Pools" value={`${stats.totalPrizeStx} STX`} accent="bg-blue-300" />
+            <Stat icon={<Users className="h-4 w-4" />} label="Active Players" value={String(stats.activePlayers)} accent="bg-pink-300" />
+          </div>
+        </section>
+
+        <section className="mb-8">
+          <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-3 overflow-hidden`}>
+            <div className="flex items-center gap-2 mb-2">
+              <Trophy className="h-4 w-4" />
+              <div className="text-xs font-black uppercase tracking-wider">Recent Winners</div>
+            </div>
+            <div className="relative h-8">
+              <motion.div
+                className="absolute whitespace-nowrap"
+                initial={{ x: 0 }}
+                animate={{ x: ['0%', '-100%'] }}
+                transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
+              >
+                {(leaders.flat().slice(0, 12)).map((w, i) => (
+                  <span key={i} className="inline-flex items-center gap-2 mr-8 text-sm">
+                    <Crown className="h-4 w-4" />
+                    <span className="font-black">{w.player?.slice(0, 6)}…{w.player?.slice(-4)}</span>
+                    <span className="opacity-70">{formatTimeSeconds(w.solveTime)}s</span>
+                  </span>
+                ))}
+              </motion.div>
+            </div>
+          </div>
+        </section>
+
+        <footer className="pb-8 text-xs opacity-70">Built for Stacks • Neo‑Brutalist UI • Framer Motion</footer>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -235,7 +235,7 @@ export default function Home() {
               const deadline = info ? Number(info.deadline) : 0;
               const blocksLeft = Math.max(0, deadline - height);
               const eta = blocksLeft > 0 ? `${blocksLeft} blocks • ≈ ${blocksToEta(blocksLeft)}` : 'Ended or pending';
-              const btnHref = d.id ? `/?puzzle=${String(d.id)}` : '#';
+              const btnHref = d.id ? `/puzzle/${String(d.id)}` : '#';
               return (
                 <motion.div
                   key={d.label}

--- a/src/pages/Puzzle.tsx
+++ b/src/pages/Puzzle.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import WalletConnect from '../components/WalletConnect';
+import useWallet from '../hooks/useWallet';
+import ChessPuzzleSolver from '../components/ChessPuzzleSolver';
+import { getPuzzlesByDifficulty, type Puzzle } from '../lib/puzzles-db';
+import { useQuery } from '@tanstack/react-query';
+import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts';
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
+
+export default function PuzzlePage() {
+  const params = useParams();
+  const puzzleIdParam = params.id || '1';
+  const numericId = Number(puzzleIdParam);
+  const { network } = useWallet();
+
+  const { data: info, isLoading, error } = useQuery<PuzzleInfo>({
+    queryKey: ['puzzle-info', network, puzzleIdParam],
+    queryFn: () => getPuzzleInfo({ puzzleId: numericId, network }),
+    refetchInterval: 15000,
+    refetchOnWindowFocus: false,
+  });
+
+  const chosen = useMemo(() => {
+    if (!info) return null as Puzzle | null;
+    const d = (info.difficulty || '').toLowerCase();
+    const list = getPuzzlesByDifficulty((d as any) || 'beginner');
+    if (!list.length) return null;
+    const idx = Math.abs((numericId || 1) - 1) % list.length;
+    return list[idx];
+  }, [info, numericId]);
+
+  const bgGrad = 'from-yellow-200 via-rose-200 to-blue-200 dark:from-zinc-900 dark:via-zinc-800 dark:to-zinc-900';
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${bgGrad} text-black dark:text-white relative overflow-hidden`}>
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+        <header className="flex items-center justify-between mb-6">
+          <Link to="/" className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur px-4 py-2 text-xl font-black tracking-tight`}>Stackmate</Link>
+          <WalletConnect />
+        </header>
+
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ type: 'spring', stiffness: 280, damping: 20 }}
+          className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-4 sm:p-6 mb-6`}
+        >
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            <div>
+              <div className="text-xs font-black uppercase tracking-wider opacity-70">Puzzle</div>
+              <div className="text-xl font-black">#{puzzleIdParam}</div>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+              <div className={`${brutal} bg-yellow-200 p-2 text-black`}>
+                <div className="uppercase font-black">Difficulty</div>
+                <div className="font-black text-sm">{info?.difficulty ?? '—'}</div>
+              </div>
+              <div className={`${brutal} bg-blue-200 p-2 text-black`}>
+                <div className="uppercase font-black">Prize Pool</div>
+                <div className="font-black text-sm">{info ? String(info.prizePool) : '—'} µSTX</div>
+              </div>
+              <div className={`${brutal} bg-green-200 p-2 text-black`}>
+                <div className="uppercase font-black">Players</div>
+                <div className="font-black text-sm">{info ? String(info.entryCount) : '—'}</div>
+              </div>
+              <div className={`${brutal} bg-pink-200 p-2 text-black`}>
+                <div className="uppercase font-black">Deadline</div>
+                <div className="font-black text-sm">{info ? String(info.deadline) : '—'}</div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        <div>
+          {isLoading && (
+            <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-6 text-center`}>Loading…</div>
+          )}
+          {error && (
+            <div className={`${brutal} bg-red-200 p-6 text-black`}>Failed to load puzzle info</div>
+          )}
+          {chosen && (
+            <ChessPuzzleSolver puzzleId={String(puzzleIdParam)} fen={chosen.fen} solution={chosen.solution} />
+          )}
+          {!isLoading && !chosen && !error && (
+            <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur p-6 text-center`}>No puzzle found</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds neo‑brutalist landing page and client-side routing.

### Changes
- Add React Router with two routes:
  - `/` → `Home`
  - `/puzzle/:id` → `PuzzlePage` (renders `ChessPuzzleSolver`)
- Implement `src/pages/Home.tsx` with:
  - Hero section (animated chess pieces, CTAs)
  - Difficulty cards (entry fee, prize pool, players, personal best, deadline countdown)
  - How it works (3 steps)
  - Recent winners ticker
  - Stats (total solved, total STX in pools, active players)
  - Neo‑brutalist UI, glassmorphism panels, gradient backgrounds, dark mode, framer-motion animations
- Implement `src/pages/Puzzle.tsx` to load on-chain puzzle info and select a matching local puzzle (fen/solution) by difficulty.
- Update links in Home cards to navigate to `/puzzle/:id`.

### Data sources
- Active puzzle IDs: `useActivePuzzles()`
- Per-puzzle info: `getPuzzleInfo()` (difficulty, prize pool, entry count, deadline, stake amount)
- Leaderboard: `getLeaderboard()` (used to compute personal bests and recent winners)
- Chain height: `GET {api}/v2/info` for deadline ETA

### Files
- `src/pages/Home.tsx` (new)
- `src/pages/Puzzle.tsx` (new)
- `src/App.tsx` (router integration)

### Rationale
Centralizes navigation and presents a polished landing experience that pulls live contract data. The Puzzle route renders the existing solver and sets up a foundation for end-to-end on-chain flow (enter, solve, claim).

### Notes / Follow-ups
- Hook "Enter Puzzle" to on-chain `enter-puzzle` tx (uses `stakeAmount` as fee).
- Optionally add deterministic mapping from on-chain puzzle IDs to specific local puzzles (by FEN/hash) so everyone sees the same puzzle.
- Add tests for routing and data panels.

### Impact
- No breaking changes. `react-router-dom` is already in dependencies.
- Works in both light/dark modes. Fully responsive.

### Screens
- Home → Hero, Difficulty, How, Stats, Winners ticker
- /puzzle/:id → Solver + puzzle info banner


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c5dcee91-80c1-4b22-8be3-4de91eb460ac/task/9f4db9f8-2736-4aa6-8a9d-920b408a965d))