### PR TITLE
Add MyWins page and prize claiming flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import PuzzlePage from './pages/Puzzle';
 import SolvePuzzle from './pages/SolvePuzzle';
+import MyWins from './pages/MyWins';
 import { Toaster } from 'sonner';
 import TransactionStatus from './components/TransactionStatus';
 
@@ -16,6 +17,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/puzzle/:id" element={<PuzzlePage />} />
           <Route path="/solve/:difficulty/:puzzleId" element={<SolvePuzzle />} />
+          <Route path="/wins" element={<MyWins />} />
         </Routes>
         <TransactionStatus />
         <Toaster richColors position="top-right" />

--- a/src/components/ClaimPrizeModal.tsx
+++ b/src/components/ClaimPrizeModal.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, Loader2, Shield, Trophy, Wallet, X } from 'lucide-react';
+import { microToStx } from '../lib/stacks';
+import useWallet from '../hooks/useWallet';
+import { useClaimPrize } from '../hooks/useContract';
+
+export type Difficulty = 'beginner' | 'intermediate' | 'expert';
+
+export interface ClaimPrizeModalProps {
+  open: boolean;
+  onClose: () => void;
+  puzzleId: number | bigint;
+  difficulty: Difficulty | string;
+  netPrizeMicro: bigint | number | string;
+  canClaimNow?: boolean;
+  onSuccess?: (txId?: string) => void;
+}
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
+
+async function toastMsg(message: string, type: 'success' | 'error' | 'info' = 'info') {
+  try {
+    const m = await import('sonner');
+    const toast = (m as any).toast as any;
+    if (!toast) return;
+    if (type === 'success') toast.success(message);
+    else if (type === 'error') toast.error(message);
+    else toast(message);
+  } catch {
+    try {
+      const m2 = await import('react-hot-toast');
+      const toast2 = (m2 as any).toast as any;
+      if (!toast2) return;
+      if (type === 'success') toast2.success(message);
+      else if (type === 'error') toast2.error(message);
+      else toast2(message);
+    } catch {}
+  }
+}
+
+export default function ClaimPrizeModal({ open, onClose, puzzleId, difficulty, netPrizeMicro, canClaimNow = true, onSuccess }: ClaimPrizeModalProps) {
+  const { balance, refresh } = useWallet();
+  const claim = useClaimPrize();
+
+  const [status, setStatus] = useState<'idle' | 'requesting_signature' | 'submitted' | 'pending' | 'success' | 'failed'>('idle');
+  const [txId, setTxId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setStatus('idle');
+      setTxId(null);
+      setError(null);
+    }
+  }, [open]);
+
+  const netStx = useMemo(() => microToStx(netPrizeMicro), [netPrizeMicro]);
+  const yourStx = balance?.stx ?? '0';
+
+  const canConfirm = open && canClaimNow && status !== 'requesting_signature' && status !== 'pending' && status !== 'submitted';
+
+  async function handleConfirm() {
+    setError(null);
+    if (!canClaimNow) {
+      await toastMsg('Prize can be claimed after the deadline', 'info');
+      return;
+    }
+    try {
+      const res = await claim.mutateAsync({
+        puzzleId,
+        onStatus: (s, d) => {
+          setStatus(s);
+          if (d?.txId) setTxId(d.txId);
+          if (s === 'requesting_signature') toastMsg('Open your wallet to sign the claim', 'info');
+          if (s === 'submitted') toastMsg('Transaction submitted. Waiting for confirmation…', 'info');
+          if (s === 'success') toastMsg('Prize claimed! 🎉', 'success');
+          if (s === 'failed') toastMsg('Claim failed. Try again.', 'error');
+        },
+      });
+      if (!res?.ok) {
+        setError(res?.error || 'Claim failed');
+        setStatus('failed');
+        return;
+      }
+      setStatus('success');
+      try { await refresh(); } catch {}
+      onSuccess?.(txId || undefined);
+      setTimeout(() => { onClose?.(); }, 1000);
+    } catch (e: any) {
+      setError(e?.message || 'Claim failed');
+      setStatus('failed');
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div className="fixed inset-0 z-50 flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <div className="absolute inset-0 bg-black/40" onClick={() => (status === 'idle' ? onClose() : null)} />
+
+          <motion.div
+            initial={{ scale: 0.9, rotate: -1, y: 8, opacity: 0 }}
+            animate={{ scale: 1, rotate: 0, y: 0, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            className={`relative max-w-lg w-[96%] sm:w-[520px] ${brutal} bg-white/80 dark:bg-zinc-900/70 backdrop-blur p-5`}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <div className="text-xl font-black">Claim Prize</div>
+              <button className={`${brutal} bg-zinc-200 px-2 py-1`} onClick={() => (status === 'idle' ? onClose() : null)}><X className="h-4 w-4"/></button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className={`${brutal} bg-yellow-200 p-3`}>
+                <div className="text-[10px] uppercase font-black">Difficulty</div>
+                <div className="text-lg font-black">{String(difficulty)}</div>
+              </div>
+              <div className={`${brutal} bg-green-200 p-3`}>
+                <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Trophy className="h-3 w-3"/> Net Prize</div>
+                <div className="text-lg font-black">{netStx} STX</div>
+              </div>
+              <div className={`${brutal} bg-white p-3`}>
+                <div className="flex items-center gap-2 text-[10px] uppercase font-black"><Wallet className="h-3 w-3"/> Your Balance</div>
+                <div className="text-lg font-black">{yourStx} STX</div>
+              </div>
+              <div className={`${brutal} ${canClaimNow ? 'bg-blue-200' : 'bg-zinc-200'} p-3`}>
+                <div className="text-[10px] uppercase font-black">Status</div>
+                <div className="text-lg font-black">{canClaimNow ? 'Ready to claim' : 'Available after deadline'}</div>
+              </div>
+            </div>
+
+            {error && (
+              <div className={`mt-3 ${brutal} bg-red-200 p-3 text-sm`}>{error}</div>
+            )}
+
+            {status !== 'idle' && (
+              <div className={`mt-3 ${brutal} ${status === 'success' ? 'bg-green-200' : status === 'failed' ? 'bg-red-200' : 'bg-blue-200'} p-3 text-sm`}>
+                {status === 'requesting_signature' && 'Waiting for wallet signature…'}
+                {status === 'submitted' && 'Transaction submitted. Waiting for confirmation…'}
+                {status === 'pending' && 'Transaction pending…'}
+                {status === 'success' && (
+                  <span className="inline-flex items-center gap-2"><CheckCircle2 className="h-4 w-4"/> Prize claimed! 🎉</span>
+                )}
+                {status === 'failed' && 'Claim failed. Please try again.'}
+                {txId && (
+                  <div className="text-xs mt-1 opacity-70 break-all">txId: {txId}</div>
+                )}
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button className={`${brutal} bg-zinc-200 hover:bg-zinc-300 px-4 py-2`} onClick={() => (status === 'idle' ? onClose() : null)} disabled={status !== 'idle'}>Cancel</button>
+              <button
+                className={`${brutal} px-4 py-2 ${canConfirm ? 'bg-black text-white hover:bg-zinc-800' : 'bg-zinc-400 text-white cursor-not-allowed'}`}
+                onClick={handleConfirm}
+                disabled={!canConfirm}
+              >
+                {status === 'requesting_signature' || status === 'submitted' || status === 'pending' ? (
+                  <span className="inline-flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin"/> Processing…</span>
+                ) : (
+                  <span className="inline-flex items-center gap-2"><Trophy className="h-4 w-4"/> Confirm Claim</span>
+                )}
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/pages/MyWins.tsx
+++ b/src/pages/MyWins.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Calendar, CheckCircle2, Clock, Trophy, Wallet, X, PartyPopper } from 'lucide-react';
+import useWallet from '../hooks/useWallet';
+import { fetchCallReadOnlyFunction, uintCV, standardPrincipalCV, ClarityType } from '@stacks/transactions';
+import { getApiBaseUrl, microToStx, type NetworkName } from '../lib/stacks';
+import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts';
+import WalletConnect from '../components/WalletConnect';
+import ClaimPrizeModal from '../components/ClaimPrizeModal';
+import { useUserStats } from '../hooks/useBlockchain';
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
+
+type WinItem = {
+  id: number;
+  info: PuzzleInfo;
+  netPrize: bigint;
+  claimed: boolean;
+  claimable: boolean;
+  solveTimeSec?: number;
+  winTimestampSec?: number;
+};
+
+function getContractIds(network: NetworkName) {
+  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
+  const [address, name] = id.split('.');
+  return { address, name };
+}
+
+function useStacksHeight(network: NetworkName) {
+  return useQuery<number>({
+    queryKey: ['stacks-height', network],
+    queryFn: async () => {
+      const res = await fetch(`${getApiBaseUrl(network)}/v2/info`);
+      const j: any = await res.json();
+      const h = Number(j?.stacks_tip_height ?? j?.stacks_tip?.height ?? j?.burn_block_height ?? 0);
+      return Number.isFinite(h) ? h : 0;
+    },
+    refetchInterval: 10000,
+    refetchOnWindowFocus: false,
+    staleTime: 8000,
+  });
+}
+
+function formatTimeSeconds(total: number | bigint) {
+  const n = typeof total === 'bigint' ? Number(total) : total;
+  const m = Math.floor(n / 60);
+  const s = n % 60;
+  const mm = m < 10 ? `0${m}` : `${m}`;
+  const ss = s < 10 ? `0${s}` : `${s}`;
+  return `${mm}:${ss}`;
+}
+
+export default function MyWins() {
+  const { network, getAddress } = useWallet();
+  const address = getAddress() || '';
+  const [wins, setWins] = useState<WinItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'claimable' | 'claimed' | 'all'>('claimable');
+  const [claimOpen, setClaimOpen] = useState(false);
+  const [selected, setSelected] = useState<WinItem | null>(null);
+  const [celebrate, setCelebrate] = useState(false);
+
+  const statsQ = useUserStats(address, !!address);
+  const heightQ = useStacksHeight(network);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      if (!address) { setWins([]); return; }
+      try {
+        setLoading(true);
+        setError(null);
+        const { address: contractAddress, name: contractName } = getContractIds(network);
+        const sender = address;
+        const cvEntries: any = await fetchCallReadOnlyFunction({
+          contractAddress,
+          contractName,
+          functionName: 'get-user-entries',
+          functionArgs: [standardPrincipalCV(address)],
+          senderAddress: sender,
+          network: (await import('../lib/stacks')).getNetwork(network),
+        });
+        const ok = cvEntries?.type === ClarityType.ResponseOk ? (cvEntries as any).value : null;
+        const arr = ok ? ((ok as any).list as any[]) : [];
+        const ids: number[] = arr.map((cv: any) => Number(cv?.value ?? 0)).filter((n: number) => Number.isFinite(n) && n > 0);
+        if (!ids.length) { if (alive) setWins([]); return; }
+        const infos = await Promise.all(ids.map((id) => getPuzzleInfo({ puzzleId: id, network }))); 
+        const withWins = infos.map((info, idx) => ({ info, id: ids[idx] }))
+          .filter((p) => (p.info?.winner || null) === address);
+        const height = heightQ.data ?? 0;
+        const items: WinItem[] = withWins.map(({ id, info }) => {
+          const gross = BigInt(info.stakeAmount) * BigInt(info.entryCount);
+          const fee = (gross * 5n) / 100n;
+          const net = gross - fee;
+          const claimed = BigInt(info.prizePool) === 0n;
+          const claimable = !claimed && height > Number(info.deadline);
+          return { id, info, netPrize: net, claimed, claimable };
+        });
+        const addMeta = await Promise.all(items.map(async (it) => {
+          try {
+            const lb = await (await import('../lib/contracts')).getLeaderboard({ puzzleId: it.id, network });
+            const you = lb.find((r) => (r.player || '').toUpperCase() === address.toUpperCase());
+            const st = you?.solveTime ? Number(you.solveTime) : undefined;
+            const ts = you?.timestamp ? Number(you.timestamp) : undefined;
+            return { ...it, solveTimeSec: st, winTimestampSec: ts } as WinItem;
+          } catch {
+            return it;
+          }
+        }));
+        if (!alive) return;
+        setWins(addMeta.sort((a, b) => (b.id - a.id)));
+      } catch (e: any) {
+        if (!alive) return;
+        setError(e?.message || 'Failed to load wins');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [address, network, heightQ.data]);
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return wins;
+    if (filter === 'claimable') return wins.filter((w) => !w.claimed);
+    return wins.filter((w) => w.claimed);
+  }, [wins, filter]);
+
+  const totalWinnings = useMemo(() => statsQ.data ? microToStx(statsQ.data.totalWinnings) : '0', [statsQ.data]);
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br from-yellow-200 via-rose-200 to-blue-200 text-black relative overflow-hidden`}>
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <div className="text-2xl sm:text-3xl font-black">My Wins</div>
+            <div className="text-xs opacity-70">Track and claim your prizes</div>
+          </div>
+          <WalletConnect />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className={`${brutal} bg-green-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Trophy className="h-4 w-4"/> Total Winnings</div>
+            <div className="text-2xl font-black">{totalWinnings} STX</div>
+          </div>
+          <div className={`${brutal} bg-blue-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Wallet className="h-4 w-4"/> Address</div>
+            <div className="text-sm font-mono break-all">{address || '—'}</div>
+          </div>
+          <div className={`${brutal} bg-white p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Clock className="h-4 w-4"/> Network Height</div>
+            <div className="text-xl font-black">{heightQ.data ?? 0}</div>
+          </div>
+        </div>
+
+        <div className="mb-4 flex items-center gap-2">
+          <button className={`${brutal} px-3 py-2 ${filter === 'claimable' ? 'bg-black text-white' : 'bg-white hover:bg-zinc-200'}`} onClick={() => setFilter('claimable')}>Claimable</button>
+          <button className={`${brutal} px-3 py-2 ${filter === 'claimed' ? 'bg-black text-white' : 'bg-white hover:bg-zinc-200'}`} onClick={() => setFilter('claimed')}>Claimed</button>
+          <button className={`${brutal} px-3 py-2 ${filter === 'all' ? 'bg-black text-white' : 'bg-white hover:bg-zinc-200'}`} onClick={() => setFilter('all')}>All</button>
+        </div>
+
+        {loading && (
+          <div className={`${brutal} bg-white p-4`}>Loading your wins…</div>
+        )}
+        {!loading && filtered.length === 0 && (
+          <div className={`${brutal} bg-white p-6 text-center`}>
+            <div className="text-lg font-black mb-1">No wins yet</div>
+            <div className="text-sm opacity-70">Solve more puzzles to win prizes!</div>
+          </div>
+        )}
+
+        <div className="grid gap-3">
+          {filtered.map((w) => {
+            const dateStr = w.winTimestampSec ? new Date(w.winTimestampSec * 1000).toLocaleString() : `After block ${String(w.info.deadline)}`;
+            const prizeStr = microToStx(w.netPrize);
+            const status = w.claimed ? 'Claimed' : 'Ready to claim';
+            const canClaimNow = !w.claimed && (heightQ.data ?? 0) > Number(w.info.deadline);
+            return (
+              <div key={w.id} className={`${brutal} bg-white/85 backdrop-blur p-4 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3`}>
+                <div>
+                  <div className="flex items-center justify-between">
+                    <div className="text-xs font-black uppercase tracking-wider">#{w.id} • {(w.info.difficulty || '').toUpperCase()}</div>
+                    <div className={`text-xs font-black ${w.claimed ? 'text-green-700' : 'text-blue-700'}`}>{status}</div>
+                  </div>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-2 text-sm">
+                    <div className={`${brutal} bg-yellow-200 p-2`}>
+                      <div className="flex items-center gap-1 text-[10px] uppercase font-black"><Calendar className="h-3 w-3"/> Date</div>
+                      <div className="font-bold truncate" title={dateStr}>{dateStr}</div>
+                    </div>
+                    <div className={`${brutal} bg-blue-200 p-2`}>
+                      <div className="flex items-center gap-1 text-[10px] uppercase font-black"><Clock className="h-3 w-3"/> Your Time</div>
+                      <div className="font-black">{w.solveTimeSec !== undefined ? formatTimeSeconds(w.solveTimeSec) : '—'}</div>
+                    </div>
+                    <div className={`${brutal} bg-green-200 p-2`}>
+                      <div className="flex items-center gap-1 text-[10px] uppercase font-black"><Trophy className="h-3 w-3"/> Prize</div>
+                      <div className="font-black">{prizeStr} STX</div>
+                    </div>
+                    <div className={`${brutal} ${w.claimed ? 'bg-green-200' : 'bg-blue-200'} p-2`}>
+                      <div className="text-[10px] uppercase font-black">Status</div>
+                      <div className="font-black">{status}</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="md:self-center">
+                  {!w.claimed ? (
+                    <button
+                      className={`${brutal} px-4 py-2 ${canClaimNow ? 'bg-black text-white hover:bg-zinc-800' : 'bg-zinc-400 text-white cursor-not-allowed'}`}
+                      onClick={() => { setSelected(w); setClaimOpen(true); }}
+                      disabled={!canClaimNow}
+                    >
+                      Claim Prize
+                    </button>
+                  ) : (
+                    <div className={`inline-flex items-center gap-2 text-green-700 font-bold`}><CheckCircle2 className="h-4 w-4"/> Claimed</div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {celebrate && (
+          <motion.div className="fixed inset-0 z-50 flex items-center justify-center"
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <div className="absolute inset-0 bg-black/20" />
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+              {Array.from({ length: 70 }).map((_, i) => (
+                <motion.div key={i}
+                  className="absolute w-2 h-2"
+                  style={{ left: `${(i * 17) % 100}%`, top: '-10px', background: i % 3 === 0 ? '#f59e0b' : i % 3 === 1 ? '#ef4444' : '#10b981', boxShadow: '2px 2px 0 #000' }}
+                  initial={{ y: -20, rotate: 0, opacity: 0 }}
+                  animate={{ y: ['-10%', '110%'], rotate: [0, 360], opacity: [0, 1, 1, 0] }}
+                  transition={{ duration: 2.4 + (i % 10) * 0.18, delay: (i % 10) * 0.06 }}
+                />
+              ))}
+            </div>
+            <motion.div className={`relative bg-white p-5 ${brutal} max-w-sm w-full mx-3 flex items-center gap-3`}
+              initial={{ scale: 0.9, rotate: -2 }} animate={{ scale: 1, rotate: 0 }} transition={{ type: 'spring', stiffness: 300, damping: 20 }}>
+              <PartyPopper className="h-6 w-6"/>
+              <div className="text-lg font-black">Prize claimed!</div>
+              <button className={`${brutal} bg-zinc-200 px-2 py-1 ml-auto`} onClick={() => setCelebrate(false)}><X className="h-4 w-4"/></button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <ClaimPrizeModal
+        open={claimOpen}
+        onClose={() => { setClaimOpen(false); setSelected(null); }}
+        puzzleId={selected?.id ?? 0}
+        difficulty={selected?.info?.difficulty || ''}
+        netPrizeMicro={selected?.netPrize ?? 0}
+        canClaimNow={!selected?.claimed && (heightQ.data ?? 0) > Number(selected?.info?.deadline ?? 0)}
+        onSuccess={() => {
+          setClaimOpen(false);
+          if (selected) {
+            setWins((prev) => prev.map((w) => w.id === selected.id ? { ...w, claimed: true, claimable: false } : w));
+          }
+          setSelected(null);
+          setCelebrate(true);
+          setTimeout(() => setCelebrate(false), 2500);
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a complete prize claiming interface.\n\nHighlights:\n- New /wins page to list user wins with filters (Claimable, Claimed, All)\n- Displays difficulty, date, winning time, net prize (after fee), and status\n- Claim button opens confirmation modal and calls claim-prize\n- Transaction status feedback and wallet balance refresh\n- Celebration animation on success\n- Route added to App.tsx\n\nFiles:\n- src/pages/MyWins.tsx\n- src/components/ClaimPrizeModal.tsx\n- src/App.tsx\n