### PR TITLE
Add Profile page with on-chain user stats, history, achievements, and chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.1.1",
         "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.9.3",
+        "recharts": "^3.2.1",
         "sonner": "^2.0.7",
         "zustand": "^5.0.8"
       },
@@ -1318,6 +1319,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@reown/appkit": {
       "version": "1.7.17",
       "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.17.tgz",
@@ -2131,6 +2157,16 @@
         "cross-fetch": "^3.1.5"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@stencil/core": {
       "version": "4.37.1",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.37.1.tgz",
@@ -2507,6 +2543,60 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2555,6 +2645,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.45.0",
@@ -4173,6 +4268,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4318,6 +4421,116 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -4360,6 +4573,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -5475,6 +5693,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5507,6 +5734,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -7027,6 +7262,34 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7130,6 +7393,45 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7144,6 +7446,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -7899,6 +8206,11 @@
         "real-require": "^0.1.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8292,6 +8604,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8330,6 +8650,27 @@
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/viem": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.1.1",
     "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.9.3",
+    "recharts": "^3.2.1",
     "sonner": "^2.0.7",
     "zustand": "^5.0.8"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Home from './pages/Home';
 import PuzzlePage from './pages/Puzzle';
 import SolvePuzzle from './pages/SolvePuzzle';
 import MyWins from './pages/MyWins';
+import Profile from './pages/Profile';
 import { Toaster } from 'sonner';
 import TransactionStatus from './components/TransactionStatus';
 
@@ -18,6 +19,7 @@ export default function App() {
           <Route path="/puzzle/:id" element={<PuzzlePage />} />
           <Route path="/solve/:difficulty/:puzzleId" element={<SolvePuzzle />} />
           <Route path="/wins" element={<MyWins />} />
+          <Route path="/profile" element={<Profile />} />
         </Routes>
         <TransactionStatus />
         <Toaster richColors position="top-right" />

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import { Calendar, CheckCircle2, Clock, Coins, Flame, Hourglass, Medal, Percent, Star, Trophy, Zap } from 'lucide-react'
+import WalletConnect from '../components/WalletConnect'
+import useWallet from '../hooks/useWallet'
+import { fetchCallReadOnlyFunction, standardPrincipalCV, uintCV, ClarityType } from '@stacks/transactions'
+import { getApiBaseUrl, microToStx, type NetworkName, getNetwork } from '../lib/stacks'
+import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts'
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, Area, AreaChart } from 'recharts'
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]'
+
+function getContractIds(network: NetworkName) {
+  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET
+  if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var')
+  const [address, name] = id.split('.')
+  return { address, name }
+}
+
+function pad(n: number) { return n < 10 ? `0${n}` : `${n}` }
+function formatTime(total: number | bigint) {
+  const v = typeof total === 'bigint' ? Number(total) : total
+  const m = Math.floor(v / 60)
+  const s = v % 60
+  return `${pad(m)}:${pad(s)}`
+}
+
+function dayKey(tsSec: number) {
+  const d = new Date(tsSec * 1000)
+  d.setHours(0, 0, 0, 0)
+  return d.toISOString().slice(0, 10)
+}
+
+export default function Profile() {
+  const { network, getAddress } = useWallet()
+  const address = getAddress() || ''
+  const [sortBy, setSortBy] = useState<'date'|'difficulty'|'time'|'result'|'prize'>('date')
+  const [sortDir, setSortDir] = useState<'asc'|'desc'>('desc')
+  const [page, setPage] = useState(1)
+  const pageSize = 10
+
+  const statsQ = useQuery<{ totalEntries: bigint; totalWins: bigint; totalWinnings: bigint }>({
+    queryKey: ['user-stats', network, address],
+    queryFn: async () => {
+      if (!address) throw new Error('no address')
+      const { address: contractAddress, name: contractName } = getContractIds(network)
+      const stxNetwork = getNetwork(network)
+      const sender = address || contractAddress
+      const cv: any = await fetchCallReadOnlyFunction({
+        contractAddress,
+        contractName,
+        functionName: 'get-user-stats',
+        functionArgs: [standardPrincipalCV(address)],
+        senderAddress: sender,
+        network: stxNetwork,
+      })
+      if (cv?.type !== ClarityType.ResponseOk) throw new Error('no stats')
+      const val: any = cv.value
+      const e = BigInt(val.data['total-entries']?.value ?? 0)
+      const w = BigInt(val.data['total-wins']?.value ?? 0)
+      const tw = BigInt(val.data['total-winnings']?.value ?? 0)
+      return { totalEntries: e, totalWins: w, totalWinnings: tw }
+    },
+    enabled: !!address,
+    refetchInterval: 30000,
+    refetchOnWindowFocus: false,
+  })
+
+  const entriesQ = useQuery<number[]>({
+    queryKey: ['user-entries', network, address],
+    queryFn: async () => {
+      const { address: contractAddress, name: contractName } = getContractIds(network)
+      const stxNetwork = getNetwork(network)
+      const sender = address || contractAddress
+      const cv: any = await fetchCallReadOnlyFunction({
+        contractAddress,
+        contractName,
+        functionName: 'get-user-entries',
+        functionArgs: [standardPrincipalCV(address)],
+        senderAddress: sender,
+        network: stxNetwork,
+      })
+      const ok = cv?.type === ClarityType.ResponseOk ? (cv as any).value : null
+      const arr = ok ? ((ok as any).list as any[]) : []
+      const ids: number[] = arr.map((cv: any) => Number(cv?.value ?? 0)).filter((n: number) => Number.isFinite(n) && n > 0)
+      return ids
+    },
+    enabled: !!address,
+    refetchInterval: 30000,
+    refetchOnWindowFocus: false,
+  })
+
+  const entryDetailQueries = useQueries({
+    queries: (entriesQ.data || []).map((id) => ({
+      queryKey: ['entry-detail', network, address, String(id)],
+      enabled: !!address,
+      refetchInterval: 30000,
+      refetchOnWindowFocus: false,
+      queryFn: async () => {
+        const { address: contractAddress, name: contractName } = getContractIds(network)
+        const stxNetwork = getNetwork(network)
+        const cv: any = await fetchCallReadOnlyFunction({
+          contractAddress,
+          contractName,
+          functionName: 'get-entry',
+          functionArgs: [uintCV(id), standardPrincipalCV(address)],
+          senderAddress: address,
+          network: stxNetwork,
+        })
+        if (cv?.type !== ClarityType.ResponseOk) return null
+        const opt = cv.value
+        if (opt?.type === ClarityType.OptionalSome) {
+          const t = opt.value
+          const solveTime = BigInt(t.data['solve-time']?.value ?? 0)
+          const timestamp = BigInt(t.data['timestamp']?.value ?? 0)
+          const ic = t.data['is-correct']
+          const isCorrect = ic?.type === ClarityType.BoolTrue
+          return { id, solveTime, timestamp, isCorrect } as { id: number; solveTime: bigint; timestamp: bigint; isCorrect: boolean }
+        }
+        return { id, solveTime: 0n, timestamp: 0n, isCorrect: false }
+      }
+    }))
+  })
+
+  const puzzleInfoQueries = useQueries({
+    queries: (entriesQ.data || []).map((id) => ({
+      queryKey: ['puzzle-info', network, String(id)],
+      queryFn: () => getPuzzleInfo({ puzzleId: id, network }),
+      enabled: (entriesQ.data || []).length > 0,
+      refetchInterval: 30000,
+      refetchOnWindowFocus: false,
+    }))
+  })
+
+  const rows = useMemo(() => {
+    const ids = entriesQ.data || []
+    const details = new Map<number, { id: number; solveTime: bigint; timestamp: bigint; isCorrect: boolean }>()
+    entryDetailQueries.forEach((q) => { const d = q.data as any; if (d && typeof d.id === 'number') details.set(d.id, d) })
+    const infos = new Map<number, PuzzleInfo>()
+    puzzleInfoQueries.forEach((q, idx) => { const id = ids[idx]; if (id && q.data) infos.set(id, q.data) })
+    const out = ids.map((id) => {
+      const d = details.get(id)
+      const info = infos.get(id)
+      const ts = d?.timestamp ? Number(d.timestamp) : 0
+      const date = ts ? new Date(ts * 1000) : null
+      const youWon = info?.winner && address && info.winner.toLowerCase() === address.toLowerCase()
+      const gross = info ? BigInt(info.stakeAmount) * BigInt(info.entryCount) : 0n
+      const fee = gross ? (gross * 5n) / 100n : 0n
+      const net = youWon ? (gross - fee) : 0n
+      return {
+        id,
+        date,
+        difficulty: info?.difficulty || '',
+        yourTime: d?.solveTime ?? 0n,
+        result: youWon ? 'Won' : (d?.isCorrect ? 'Solved' : 'Lost'),
+        prizeMicro: net,
+      }
+    })
+    return out
+  }, [entriesQ.data, entryDetailQueries.map((q) => q.data).join('|'), puzzleInfoQueries.map((q) => q.data ? JSON.stringify(q.data) : '').join('|'), address])
+
+  const solvedRows = useMemo(() => rows.filter((r) => r.result === 'Won' || r.result === 'Solved'), [rows])
+  const solvedTimes = useMemo(() => solvedRows.map((r) => Number(r.yourTime)).filter((n) => Number.isFinite(n) && n > 0), [solvedRows])
+  const avgSolve = useMemo(() => {
+    if (!solvedTimes.length) return 0
+    const sum = solvedTimes.reduce((a, b) => a + b, 0)
+    return Math.round(sum / solvedTimes.length)
+  }, [solvedTimes])
+  const bestSolve = useMemo(() => solvedTimes.length ? Math.min(...solvedTimes) : 0, [solvedTimes])
+
+  const currentStreak = useMemo(() => {
+    const solved = rows.filter((r) => r.result === 'Won' || r.result === 'Solved' ).filter((r) => r.date)
+    if (!solved.length) return 0
+    const days = new Set(solved.map((r) => dayKey(Math.floor(r.date!.getTime()/1000))))
+    const today = new Date(); today.setHours(0,0,0,0)
+    let streak = 0
+    for (;;) {
+      const key = today.toISOString().slice(0,10)
+      if (days.has(key)) { streak += 1; today.setDate(today.getDate()-1) } else { break }
+    }
+    return streak
+  }, [rows])
+
+  const winRatePct = useMemo(() => {
+    const t = Number(statsQ.data?.totalEntries || 0n)
+    const w = Number(statsQ.data?.totalWins || 0n)
+    if (!t) return 0
+    return Math.round((w / t) * 100)
+  }, [statsQ.data])
+
+  const dailyData = useMemo(() => {
+    const map = new Map<string, { date: string; entries: number; wins: number }>()
+    rows.forEach((r) => {
+      if (!r.date) return
+      const key = dayKey(Math.floor(r.date.getTime()/1000))
+      if (!map.has(key)) map.set(key, { date: key, entries: 0, wins: 0 })
+      const obj = map.get(key)!
+      obj.entries += 1
+      if (r.result === 'Won') obj.wins += 1
+    })
+    const arr = Array.from(map.values()).sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+    let cumWins = 0
+    let cumEntries = 0
+    return arr.map((d) => {
+      cumWins += d.wins
+      cumEntries += d.entries
+      const rate = cumEntries ? Math.round((cumWins / cumEntries) * 100) : 0
+      return { ...d, rate }
+    })
+  }, [rows])
+
+  const sortedRows = useMemo(() => {
+    const copy = [...rows]
+    copy.sort((a, b) => {
+      const mult = sortDir === 'asc' ? 1 : -1
+      if (sortBy === 'date') return mult * (((a.date?.getTime()||0) - (b.date?.getTime()||0)))
+      if (sortBy === 'difficulty') return mult * a.difficulty.localeCompare(b.difficulty)
+      if (sortBy === 'time') return mult * (Number(a.yourTime) - Number(b.yourTime))
+      if (sortBy === 'result') return mult * a.result.localeCompare(b.result)
+      if (sortBy === 'prize') return mult * (Number(a.prizeMicro) - Number(b.prizeMicro))
+      return 0
+    })
+    return copy
+  }, [rows, sortBy, sortDir])
+
+  const pagedRows = useMemo(() => {
+    const start = (page - 1) * pageSize
+    return sortedRows.slice(start, start + pageSize)
+  }, [sortedRows, page])
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil((rows.length || 0) / pageSize)), [rows.length])
+
+  const achievements = useMemo(() => {
+    const totalWins = Number(statsQ.data?.totalWins || 0n)
+    const totalEntries = Number(statsQ.data?.totalEntries || 0n)
+    const totalWinningsStx = microToStx(statsQ.data?.totalWinnings || 0n)
+    const speedDemon = solvedTimes.some((t) => t > 0 && t < 60)
+    const consistent = currentStreak >= 5
+    const firstWin = totalWins >= 1
+    const tenSolved = solvedRows.length >= 10
+    const marathon = totalEntries >= 50
+    return [
+      { key: 'first', label: 'First Win', achieved: firstWin, icon: <Trophy className="h-4 w-4"/>, desc: 'Win your first puzzle' },
+      { key: 'ten', label: '10 Puzzles Solved', achieved: tenSolved, icon: <Medal className="h-4 w-4"/>, desc: 'Solve 10 puzzles' },
+      { key: 'speed', label: 'Speed Demon', achieved: speedDemon, icon: <Zap className="h-4 w-4"/>, desc: 'Solve in under 1 min' },
+      { key: 'streak', label: 'Consistent', achieved: consistent, icon: <Flame className="h-4 w-4"/>, desc: '5 day streak' },
+      { key: 'marathon', label: 'Marathoner', achieved: marathon, icon: <Hourglass className="h-4 w-4"/>, desc: 'Enter 50 puzzles' },
+      { key: 'bank', label: 'Bankroller', achieved: Number(totalWinningsStx) >= 100, icon: <Coins className="h-4 w-4"/>, desc: 'Win 100+ STX' },
+    ]
+  }, [statsQ.data, solvedTimes, currentStreak, solvedRows])
+
+  const bgGrad = 'from-yellow-200 via-rose-200 to-blue-200 dark:from-zinc-900 dark:via-zinc-800 dark:to-zinc-900'
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${bgGrad} text-black dark:text-white relative overflow-hidden`}>
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+        <header className="flex items-center justify-between mb-6">
+          <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur px-4 py-2 text-xl font-black tracking-tight`}>Profile</div>
+          <WalletConnect />
+        </header>
+
+        <section className="mb-8 grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className={`${brutal} bg-white/85 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Star className="h-4 w-4"/> Total Entered</div>
+            <div className="text-2xl font-black">{String(statsQ.data?.totalEntries ?? 0n)}</div>
+          </div>
+          <div className={`${brutal} bg-green-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Trophy className="h-4 w-4"/> Total Solved</div>
+            <div className="text-2xl font-black">{String(statsQ.data?.totalWins ?? 0n)}</div>
+          </div>
+          <div className={`${brutal} bg-blue-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Percent className="h-4 w-4"/> Win Rate</div>
+            <div className="text-2xl font-black">{winRatePct}%</div>
+          </div>
+          <div className={`${brutal} bg-yellow-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Coins className="h-4 w-4"/> Total STX Won</div>
+            <div className="text-2xl font-black">{microToStx(statsQ.data?.totalWinnings ?? 0n)} STX</div>
+          </div>
+          <div className={`${brutal} bg-pink-200 p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Clock className="h-4 w-4"/> Avg Solve Time</div>
+            <div className="text-2xl font-black">{avgSolve ? formatTime(avgSolve) : '—'}</div>
+          </div>
+          <div className={`${brutal} bg-white p-4`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Medal className="h-4 w-4"/> Best Solve Time</div>
+            <div className="text-2xl font-black">{bestSolve ? formatTime(bestSolve) : '—'}</div>
+          </div>
+          <div className={`${brutal} bg-orange-200 p-4 md:col-span-3`}>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wider"><Flame className="h-4 w-4"/> Current Streak</div>
+            <div className="text-2xl font-black">{currentStreak} day{currentStreak === 1 ? '' : 's'}</div>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <div className="flex items-center gap-2 mb-2"><Percent className="h-4 w-4"/><div className="text-xs font-black uppercase tracking-wider">Win Rate Over Time</div></div>
+          <div className={`${brutal} bg-white/85 backdrop-blur p-3 h-64`}>
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={dailyData} margin={{ left: 8, right: 8, top: 8, bottom: 8 }}>
+                <defs>
+                  <linearGradient id="grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.6}/>
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0.05}/>
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#00000020" />
+                <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+                <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} />
+                <Tooltip formatter={(v: any, n: any) => n === 'rate' ? [`${v}%`, 'Win Rate'] : v} />
+                <Area type="monotone" dataKey="rate" stroke="#16a34a" fillOpacity={1} fill="url(#grad)" />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <div className="flex items-center gap-2 mb-2"><Medal className="h-4 w-4"/><div className="text-xs font-black uppercase tracking-wider">Achievements</div></div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {achievements.map((a) => (
+              <div key={a.key} className={`${brutal} ${a.achieved ? 'bg-green-200' : 'bg-white'} p-3 flex items-start gap-3`}>
+                <div className={`h-8 w-8 ${brutal} flex items-center justify-center ${a.achieved ? 'bg-black text-white' : 'bg-zinc-200 text-black'}`}>{a.icon}</div>
+                <div>
+                  <div className="font-black">{a.label}</div>
+                  <div className="text-xs opacity-70">{a.desc}</div>
+                </div>
+                <div className="ml-auto self-center">{a.achieved ? <CheckCircle2 className="h-5 w-5 text-green-700"/> : <Clock className="h-5 w-5 opacity-50"/>}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2"><Calendar className="h-4 w-4"/><div className="text-xs font-black uppercase tracking-wider">History</div></div>
+            <div className="text-xs opacity-70">{rows.length} entries</div>
+          </div>
+          <div className={`${brutal} bg-white/90 backdrop-blur overflow-hidden`}>
+            <div className="overflow-auto">
+              <table className="min-w-full text-sm">
+                <thead className="bg-zinc-100">
+                  <tr>
+                    <th className="text-left p-2 cursor-pointer" onClick={() => { setSortBy('date'); setSortDir(sortBy === 'date' && sortDir === 'desc' ? 'asc' : 'desc') }}>Date</th>
+                    <th className="text-left p-2 cursor-pointer" onClick={() => { setSortBy('difficulty'); setSortDir(sortBy === 'difficulty' && sortDir === 'desc' ? 'asc' : 'desc') }}>Difficulty</th>
+                    <th className="text-left p-2 cursor-pointer" onClick={() => { setSortBy('time'); setSortDir(sortBy === 'time' && sortDir === 'desc' ? 'asc' : 'desc') }}>Your Time</th>
+                    <th className="text-left p-2 cursor-pointer" onClick={() => { setSortBy('result'); setSortDir(sortBy === 'result' && sortDir === 'desc' ? 'asc' : 'desc') }}>Result</th>
+                    <th className="text-left p-2 cursor-pointer" onClick={() => { setSortBy('prize'); setSortDir(sortBy === 'prize' && sortDir === 'desc' ? 'asc' : 'desc') }}>Prize</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedRows.map((r) => (
+                    <tr key={r.id} className="border-t border-zinc-200">
+                      <td className="p-2 whitespace-nowrap">{r.date ? r.date.toLocaleString() : '—'}</td>
+                      <td className="p-2 whitespace-nowrap">{r.difficulty || '—'}</td>
+                      <td className="p-2 whitespace-nowrap">{Number(r.yourTime) ? `${formatTime(Number(r.yourTime))}` : '—'}</td>
+                      <td className="p-2 whitespace-nowrap">{r.result}</td>
+                      <td className="p-2 whitespace-nowrap">{r.prizeMicro ? `${microToStx(r.prizeMicro)} STX` : '—'}</td>
+                    </tr>
+                  ))}
+                  {pagedRows.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="p-3 text-center text-xs">No entries yet</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex items-center justify-between p-2 border-t border-zinc-200 text-xs">
+              <div>Page {page} of {totalPages}</div>
+              <div className="flex items-center gap-2">
+                <button className={`${brutal} px-2 py-1 bg-white disabled:opacity-50`} disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p-1))}>Prev</button>
+                <button className={`${brutal} px-2 py-1 bg-white disabled:opacity-50`} disabled={page >= totalPages} onClick={() => setPage((p) => Math.min(totalPages, p+1))}>Next</button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Title: Add user Profile page with on-chain stats, history, achievements, and chart

Summary
- Add Profile page that aggregates on-chain user stats via contract read-only calls and React Query caching
- Implement history table (sortable, paginated) for all entered puzzles with result and prize calculation
- Add achievement badges and a win-rate-over-time chart (Recharts)

Details
- New page: src/pages/Profile.tsx
  - Stats card: total entries, total wins, win rate, total STX won, avg/best solve time, current streak
  - History table: date, difficulty, your time, result, prize; sortable columns; pagination (10 per page)
  - Achievements: first win, 10 solved, speed demon (< 1 min), consistent (5-day streak), marathoner, bankroller
  - Chart: cumulative win rate over time using daily aggregates (Recharts)
  - All data fetched from the Clarity contract via read-only endpoints and cached with React Query
- Routing: add /profile route in App.tsx
- Dependency: add recharts to dependencies

Notes
- No server changes required; relies on existing contract endpoints: get-user-stats, get-user-entries, get-entry, get-puzzle-info
- Styling follows existing Neo‑Brutalist Tailwind aesthetic

Testing
- Connect a wallet on testnet
- Visit /profile to see stats and history
- Sorting toggles by clicking table headers; use pagination controls at bottom



₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ff4d8f00-70d1-4d8d-b09f-36e32962f612/task/9e52af76-1e14-4289-a6a4-4b5180159e13))