### PR TITLE
Add NotificationBell and notifications system; integrate into headers

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -6,7 +6,7 @@ import { formatRelativeTime } from '../lib/time-utils';
 const brutal = 'rounded-none border-[3px] border-black shadow-[6px_6px_0_#000]';
 
 export default function NotificationBell() {
-  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications();
+  const { notifications, unreadCount, markAsRead, markAllAsRead, enableSound, enableDesktop, desktopPermission, setEnableSound, setEnableDesktop } = useNotifications();
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
 
@@ -24,7 +24,22 @@ export default function NotificationBell() {
       {open && (
         <div className={`absolute right-0 mt-2 w-80 bg-white ${brutal} z-50`}>
           <div className="flex items-center justify-between px-3 py-2 border-b border-black/20">
-            <div className="text-xs font-black uppercase tracking-wider">Notifications</div>
+            <div>
+              <div className="text-xs font-black uppercase tracking-wider">Notifications</div>
+              <div className="flex items-center gap-2 mt-1">
+                <label className="flex items-center gap-1 text-[11px]">
+                  <input type="checkbox" checked={enableSound} onChange={(e) => setEnableSound(e.target.checked)} />
+                  Sound
+                </label>
+                <label className="flex items-center gap-1 text-[11px]">
+                  <input type="checkbox" checked={enableDesktop} onChange={(e) => setEnableDesktop(e.target.checked)} disabled={desktopPermission === 'denied' || desktopPermission === 'unsupported'} />
+                  Desktop
+                </label>
+                {(desktopPermission === 'denied') && (
+                  <span className="text-[10px] opacity-70">(blocked in browser)</span>
+                )}
+              </div>
+            </div>
             {unreadCount > 0 && (
               <button className={`text-xs bg-yellow-300 px-2 py-1 ${brutal}`} onClick={() => markAllAsRead()}>Mark all read</button>
             )}

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,48 @@
+import { useMemo, useRef, useState } from 'react';
+import { Bell } from 'lucide-react';
+import useNotifications from '../hooks/useNotifications';
+import { formatRelativeTime } from '../lib/time-utils';
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[6px_6px_0_#000]';
+
+export default function NotificationBell() {
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  const top = useMemo(() => notifications.slice(0, 10), [notifications]);
+
+  return (
+    <div className="relative">
+      <button ref={btnRef} className={`relative inline-flex items-center justify-center h-9 w-9 bg-white ${brutal}`} onClick={() => setOpen(o => !o)} aria-label="Notifications">
+        <Bell className="h-4 w-4" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-600 text-white text-[10px] leading-none px-1.5 py-0.5 rounded-full border-[2px] border-black shadow-[2px_2px_0_#000]">{unreadCount}</span>
+        )}
+      </button>
+
+      {open && (
+        <div className={`absolute right-0 mt-2 w-80 bg-white ${brutal} z-50`}>
+          <div className="flex items-center justify-between px-3 py-2 border-b border-black/20">
+            <div className="text-xs font-black uppercase tracking-wider">Notifications</div>
+            {unreadCount > 0 && (
+              <button className={`text-xs bg-yellow-300 px-2 py-1 ${brutal}`} onClick={() => markAllAsRead()}>Mark all read</button>
+            )}
+          </div>
+          <div className="max-h-80 overflow-auto">
+            {top.length === 0 && (
+              <div className="px-3 py-4 text-sm opacity-70">No notifications</div>
+            )}
+            {top.map((n) => (
+              <div key={n.id} className={`px-3 py-2 border-b border-black/10 ${!n.read ? 'bg-yellow-100' : 'bg-white'}`} onClick={() => markAsRead(n.id)}>
+                <div className="text-sm font-bold">{n.message}</div>
+                <div className="text-[11px] opacity-60">{formatRelativeTime(n.createdAt)}</div>
+              </div>
+            ))}
+          </div>
+          <div className="px-3 py-2 text-[11px] opacity-60">Showing latest 10</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,284 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useWallet from './useWallet';
+import { getPuzzleInfo, getLeaderboard, type PuzzleInfo } from '../lib/contracts';
+import { fetchCallReadOnlyFunction, standardPrincipalCV, uintCV, ClarityType } from '@stacks/transactions';
+import { getApiBaseUrl, getNetwork, microToStx, type NetworkName } from '../lib/stacks';
+
+export type NotificationType = 'win' | 'new_puzzle' | 'deadline_soon' | 'overtaken';
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  message: string;
+  puzzleId?: number;
+  difficulty?: string;
+  amountStx?: string;
+  rankChange?: { from: number; to: number };
+  createdAt: number; // ms
+  read: boolean;
+}
+
+interface MetaState {
+  lastSeenPuzzleCount?: number;
+  winNotified?: Record<string, boolean>; // key: puzzleId
+  deadlineWarned?: Record<string, boolean>;
+  prevRanks?: Record<string, number>; // key: puzzleId
+}
+
+function getContractIds(network: NetworkName) {
+  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
+  const [address, name] = id.split('.');
+  return { address, name };
+}
+
+function storageKeys(network: NetworkName, address: string | null) {
+  const who = address || 'guest';
+  return {
+    notif: `stackmate:notifs:${network}:${who}`,
+    meta: `stackmate:notifs:meta:${network}:${who}`,
+  };
+}
+
+function now() { return Date.now(); }
+
+export default function useNotifications() {
+  const { network, getAddress } = useWallet();
+  const address = getAddress();
+  const keys = storageKeys(network, address);
+
+  const [notifications, setNotifications] = useState<NotificationItem[]>(() => {
+    try {
+      const raw = localStorage.getItem(keys.notif);
+      if (raw) return JSON.parse(raw);
+    } catch {}
+    return [];
+  });
+
+  const metaRef = useRef<MetaState>(() => {
+    try {
+      const raw = localStorage.getItem(keys.meta);
+      if (raw) return JSON.parse(raw);
+    } catch {}
+    return {};
+  }) as React.MutableRefObject<MetaState>;
+
+  useEffect(() => {
+    // reload when identity key changes
+    try {
+      const rawNotif = localStorage.getItem(keys.notif);
+      setNotifications(rawNotif ? JSON.parse(rawNotif) : []);
+      const rawMeta = localStorage.getItem(keys.meta);
+      metaRef.current = rawMeta ? JSON.parse(rawMeta) : {};
+    } catch {
+      setNotifications([]);
+      metaRef.current = {};
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [network, address]);
+
+  const save = useCallback((list: NotificationItem[], meta?: MetaState) => {
+    try { localStorage.setItem(keys.notif, JSON.stringify(list)); } catch {}
+    if (meta) {
+      try { localStorage.setItem(keys.meta, JSON.stringify(meta)); } catch {}
+    }
+  }, [keys.notif, keys.meta]);
+
+  const addNotification = useCallback((n: NotificationItem) => {
+    setNotifications((prev) => {
+      // prevent exact duplicate ids
+      if (prev.some(x => x.id === n.id)) return prev;
+      const next = [n, ...prev].slice(0, 100);
+      save(next);
+      return next;
+    });
+  }, [save]);
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications((prev) => {
+      const next = prev.map(n => n.id === id ? { ...n, read: true } : n);
+      save(next);
+      return next;
+    });
+  }, [save]);
+
+  const markAllAsRead = useCallback(() => {
+    setNotifications((prev) => {
+      const next = prev.map(n => ({ ...n, read: true }));
+      save(next);
+      return next;
+    });
+  }, [save]);
+
+  const unreadCount = useMemo(() => notifications.filter(n => !n.read).length, [notifications]);
+
+  const pollOnce = useCallback(async () => {
+    try {
+      const addr = address;
+      const { address: contractAddress, name: contractName } = getContractIds(network);
+      const stxNetwork = getNetwork(network);
+
+      // New puzzles check via puzzle count
+      const countCv: any = await fetchCallReadOnlyFunction({
+        contractAddress,
+        contractName,
+        functionName: 'get-puzzle-count',
+        functionArgs: [],
+        senderAddress: addr || contractAddress,
+        network: stxNetwork,
+      });
+      const okCount = countCv?.type === ClarityType.ResponseOk ? (countCv as any).value : null;
+      const total = okCount ? (okCount as any).value as bigint : 0n;
+      const totalNum = Number(total);
+
+      const meta = metaRef.current || {};
+      const winNotified = { ...(meta.winNotified || {}) };
+      const deadlineWarned = { ...(meta.deadlineWarned || {}) };
+      const prevRanks = { ...(meta.prevRanks || {}) };
+
+      if (Number.isFinite(totalNum)) {
+        const lastSeen = meta.lastSeenPuzzleCount ?? 0;
+        if (totalNum > lastSeen) {
+          // Notify per new puzzle id (lastSeen+1..totalNum)
+          const newIds = Array.from({ length: totalNum - lastSeen }, (_, i) => i + lastSeen + 1);
+          for (const id of newIds) {
+            try {
+              const info = await getPuzzleInfo({ puzzleId: id, network });
+              const msg = info?.difficulty ? `New ${String(info.difficulty).charAt(0).toUpperCase() + String(info.difficulty).slice(1)} puzzle available` : 'New puzzle available';
+              addNotification({
+                id: `new:${id}`,
+                type: 'new_puzzle',
+                message: msg,
+                puzzleId: id,
+                difficulty: info?.difficulty,
+                createdAt: now(),
+                read: false,
+              });
+            } catch {}
+          }
+          metaRef.current = { ...meta, lastSeenPuzzleCount: totalNum, winNotified, deadlineWarned, prevRanks };
+          save(notifications, metaRef.current);
+        }
+      }
+
+      if (!addr) return; // user-specific checks below
+
+      // Fetch user entries
+      const entriesCv: any = await fetchCallReadOnlyFunction({
+        contractAddress,
+        contractName,
+        functionName: 'get-user-entries',
+        functionArgs: [standardPrincipalCV(addr)],
+        senderAddress: addr,
+        network: stxNetwork,
+      });
+      const okEntries = entriesCv?.type === ClarityType.ResponseOk ? (entriesCv as any).value : null;
+      const entryIds: number[] = okEntries ? ((okEntries as any).list as any[]).map((cv: any) => Number(cv?.value ?? 0)).filter((n: number) => Number.isFinite(n) && n > 0) : [];
+
+      // Current chain height for deadline checks
+      let height = 0;
+      try {
+        const res = await fetch(`${getApiBaseUrl(network)}/v2/info`);
+        const j: any = await res.json();
+        height = Number(j?.stacks_tip_height ?? j?.stacks_tip?.height ?? j?.burn_block_height ?? 0) || 0;
+      } catch {}
+
+      // Iterate entries: wins, deadline soon, overtaken
+      for (const id of entryIds) {
+        try {
+          const info: PuzzleInfo = await getPuzzleInfo({ puzzleId: id, network });
+
+          // Win notification
+          const youWon = info?.winner && addr && info.winner.toLowerCase() === addr.toLowerCase();
+          if (youWon && !winNotified[String(id)]) {
+            const gross = BigInt(info.stakeAmount) * BigInt(info.entryCount);
+            const fee = (gross * 5n) / 100n;
+            const net = gross - fee;
+            const amount = microToStx(net);
+            const diff = (info?.difficulty || '');
+            const label = diff ? (diff.charAt(0).toUpperCase() + diff.slice(1)) : '';
+            addNotification({
+              id: `win:${id}`,
+              type: 'win',
+              message: `You won ${label} puzzle! Claim ${amount} STX`,
+              puzzleId: id,
+              difficulty: info?.difficulty,
+              amountStx: amount,
+              createdAt: now(),
+              read: false,
+            });
+            winNotified[String(id)] = true;
+          }
+
+          // Deadline soon (<= 1 hour) for active puzzles
+          const active = Boolean(info?.isActive);
+          const dlBlock = Number(info?.deadline || 0);
+          const blocksLeft = Math.max(0, dlBlock - (height || 0));
+          const secondsLeft = blocksLeft * 600; // approx 10 minutes per block
+          if (active && secondsLeft > 0 && secondsLeft <= 3600 && !deadlineWarned[String(id)]) {
+            addNotification({
+              id: `deadline:${id}`,
+              type: 'deadline_soon',
+              message: 'Puzzle deadline in 1 hour',
+              puzzleId: id,
+              difficulty: info?.difficulty,
+              createdAt: now(),
+              read: false,
+            });
+            deadlineWarned[String(id)] = true;
+          }
+
+          // Overtaken detection (leaderboard rank worsened)
+          try {
+            const lb = await getLeaderboard({ puzzleId: id, network });
+            const idx = lb.findIndex(x => (x.player || '').toLowerCase() === addr.toLowerCase());
+            if (idx >= 0) {
+              const rank = idx + 1;
+              const prev = prevRanks[String(id)];
+              if (typeof prev === 'number' && rank > prev) {
+                addNotification({
+                  id: `overtaken:${id}:${rank}`,
+                  type: 'overtaken',
+                  message: 'Someone overtook your position!',
+                  puzzleId: id,
+                  difficulty: info?.difficulty,
+                  rankChange: { from: prev, to: rank },
+                  createdAt: now(),
+                  read: false,
+                });
+              }
+              prevRanks[String(id)] = rank;
+            }
+          } catch {}
+        } catch {}
+      }
+
+      metaRef.current = { lastSeenPuzzleCount: metaRef.current?.lastSeenPuzzleCount ?? totalNum, winNotified, deadlineWarned, prevRanks };
+      save(notifications, metaRef.current);
+    } catch {}
+  }, [address, network, notifications, save, addNotification]);
+
+  useEffect(() => {
+    let id: any;
+    let stopped = false;
+
+    const run = async () => {
+      if (document.visibilityState !== 'visible') return;
+      await pollOnce();
+    };
+
+    run();
+    id = setInterval(run, 30_000);
+
+    const onVis = () => { if (!stopped && document.visibilityState === 'visible') run(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => { stopped = true; clearInterval(id); document.removeEventListener('visibilitychange', onVis); };
+  }, [pollOnce]);
+
+  return {
+    notifications: useMemo(() => [...notifications].sort((a, b) => b.createdAt - a.createdAt), [notifications]),
+    unreadCount,
+    markAsRead,
+    markAllAsRead,
+  };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import WalletConnect from '../components/WalletConnect';
+import NotificationBell from '../components/NotificationBell';
 import useWallet from '../hooks/useWallet';
 import { useActivePuzzles } from '../hooks/useBlockchain';
 import { getPuzzleInfo, getLeaderboard, type LeaderboardEntry, type PuzzleInfo } from '../lib/contracts';
@@ -213,7 +214,10 @@ export default function Home() {
       <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-14 lg:py-20">
         <header className="flex items-center justify-between mb-8 sm:mb-12">
           <div className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur px-4 py-2 text-xl font-black tracking-tight`}>Stackmate</div>
-          <WalletConnect />
+          <div className="flex items-center gap-2">
+            <NotificationBell />
+            <WalletConnect />
+          </div>
         </header>
 
         <section className="mb-14 sm:mb-20">

--- a/src/pages/MyWins.tsx
+++ b/src/pages/MyWins.tsx
@@ -7,6 +7,7 @@ import { fetchCallReadOnlyFunction, uintCV, standardPrincipalCV, ClarityType } f
 import { getApiBaseUrl, microToStx, type NetworkName } from '../lib/stacks';
 import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts';
 import WalletConnect from '../components/WalletConnect';
+import NotificationBell from '../components/NotificationBell';
 import ClaimPrizeModal from '../components/ClaimPrizeModal';
 import { useUserStats } from '../hooks/useBlockchain';
 
@@ -139,7 +140,10 @@ export default function MyWins() {
             <div className="text-2xl sm:text-3xl font-black">My Wins</div>
             <div className="text-xs opacity-70">Track and claim your prizes</div>
           </div>
-          <WalletConnect />
+          <div className="flex items-center gap-2">
+            <NotificationBell />
+            <WalletConnect />
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">

--- a/src/pages/Puzzle.tsx
+++ b/src/pages/Puzzle.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import WalletConnect from '../components/WalletConnect';
+import NotificationBell from '../components/NotificationBell';
 import useWallet from '../hooks/useWallet';
 import ChessPuzzleSolver from '../components/ChessPuzzleSolver';
 import { getPuzzlesByDifficulty, type Puzzle } from '../lib/puzzles-db';
@@ -39,7 +40,10 @@ export default function PuzzlePage() {
       <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         <header className="flex items-center justify-between mb-6">
           <Link to="/" className={`${brutal} bg-white/80 dark:bg-zinc-900/60 backdrop-blur px-4 py-2 text-xl font-black tracking-tight`}>Stackmate</Link>
-          <WalletConnect />
+          <div className="flex items-center gap-2">
+            <NotificationBell />
+            <WalletConnect />
+          </div>
         </header>
 
         <motion.div


### PR DESCRIPTION
Title: Add NotificationBell and useNotifications hook; integrate into headers

Summary
- Adds a persistent notifications system with polling and localStorage storage.
- NotificationBell component displays unread badge and dropdown list.
- Integrates the bell into Home, Puzzle, and My Wins headers.

Details
- New hook: src/hooks/useNotifications.ts
  - Polls every 30s when tab is visible
  - Checks: user wins, new puzzles available, deadline approaching (<= 1h), and when the user is overtaken on leaderboards
  - Persists notifications and meta state (winNotified, deadlineWarned, prevRanks, lastSeenPuzzleCount) per network+address in localStorage
  - Exposes notifications list, unread count, markAsRead, markAllAsRead
- New component: src/components/NotificationBell.tsx
  - Bell icon with unread badge
  - Click to open dropdown showing latest notifications (with relative timestamps)
  - Mark-as-read on click and mark-all as read
- Header integration
  - Added NotificationBell next to WalletConnect on Home, Puzzle, and My Wins pages

Examples of notifications
- "You won Intermediate puzzle! Claim 22.8 STX"
- "New puzzle available"
- "Puzzle deadline in 1 hour"
- "Someone overtook your position!"

Notes
- Uses contract read-only calls for data; rate-limited via 30s polling and visibility.
- Avoids duplicate notifications using stored per-puzzle metadata.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ff4d8f00-70d1-4d8d-b09f-36e32962f612/task/9e52af76-1e14-4289-a6a4-4b5180159e13))