### PR TITLE
Add social sharing utilities and buttons; integrate into success screens

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,58 @@
+import { useMemo, useState } from 'react';
+import { Share2, Twitter, Copy } from 'lucide-react';
+import { generateShareText, shareToTwitter, copyToClipboard, type ShareType } from '../lib/share-utils';
+
+const brutal = 'rounded-none border-[3px] border-black shadow-[6px_6px_0_#000]';
+
+async function toastMsg(message: string, type: 'success' | 'error' | 'info' = 'info') {
+  try {
+    const m = await import('sonner');
+    const toast = (m as any).toast as any;
+    if (!toast) return;
+    if (type === 'success') toast.success(message);
+    else if (type === 'error') toast.error(message);
+    else toast(message);
+  } catch {
+    try {
+      const m2 = await import('react-hot-toast');
+      const toast2 = (m2 as any).toast as any;
+      if (!toast2) return;
+      if (type === 'success') toast2.success(message);
+      else if (type === 'error') toast2.error(message);
+      else toast2(message);
+    } catch {}
+  }
+}
+
+export interface ShareButtonProps {
+  type: ShareType;
+  data?: any;
+  url?: string;
+  className?: string;
+  label?: string;
+}
+
+export default function ShareButton({ type, data, url, className = '', label = 'Share' }: ShareButtonProps) {
+  const text = useMemo(() => generateShareText(type, data), [type, data]);
+  const shareUrl = useMemo(() => url || (typeof window !== 'undefined' ? window.location.origin : ''), [url]);
+
+  return (
+    <div className={`inline-flex items-center gap-2 ${className}`}>
+      <button
+        className={`${brutal} bg-blue-300 hover:bg-blue-400 px-3 py-2 inline-flex items-center gap-2`}
+        onClick={() => shareToTwitter(text, shareUrl)}
+      >
+        <Twitter className="h-4 w-4" /> Tweet
+      </button>
+      <button
+        className={`${brutal} bg-white hover:bg-zinc-100 px-3 py-2 inline-flex items-center gap-2`}
+        onClick={async () => {
+          const ok = await copyToClipboard(`${text}${shareUrl ? ` ${shareUrl}` : ''}`);
+          toastMsg(ok ? 'Link copied to clipboard' : 'Copy failed', ok ? 'success' : 'error');
+        }}
+      >
+        <Copy className="h-4 w-4" /> Copy link
+      </button>
+    </div>
+  );
+}

--- a/src/lib/share-utils.ts
+++ b/src/lib/share-utils.ts
@@ -1,0 +1,45 @@
+export type ShareType = 'solve' | 'win' | 'invite';
+
+export function generateShareText(type: ShareType, data?: any): string {
+  if (type === 'solve') {
+    const t = data?.durationText || data?.duration || '';
+    return `I just solved a chess puzzle in ${t}! Think you can beat me? 🏆`;
+  }
+  if (type === 'win') {
+    const amt = data?.amountStx || data?.amount || '';
+    return `I won ${amt} STX playing chess puzzles! 💰`;
+  }
+  return 'Join me solving chess puzzles for STX';
+}
+
+export function shareToTwitter(text: string, url?: string) {
+  try {
+    const base = 'https://twitter.com/intent/tweet';
+    const params = new URLSearchParams();
+    params.set('text', text);
+    if (url) params.set('url', url);
+    const href = `${base}?${params.toString()}`;
+    window.open(href, '_blank', 'noopener,noreferrer');
+  } catch {}
+}
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {}
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+    return true;
+  } catch {}
+  return false;
+}

--- a/src/pages/MyWins.tsx
+++ b/src/pages/MyWins.tsx
@@ -9,6 +9,7 @@ import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts';
 import WalletConnect from '../components/WalletConnect';
 import NotificationBell from '../components/NotificationBell';
 import ClaimPrizeModal from '../components/ClaimPrizeModal';
+import ShareButton from '../components/ShareButton';
 import { useUserStats } from '../hooks/useBlockchain';
 
 const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
@@ -64,6 +65,7 @@ export default function MyWins() {
   const [claimOpen, setClaimOpen] = useState(false);
   const [selected, setSelected] = useState<WinItem | null>(null);
   const [celebrate, setCelebrate] = useState(false);
+  const [lastClaimAmountStx, setLastClaimAmountStx] = useState<string | null>(null);
 
   const statsQ = useUserStats(address, !!address);
   const heightQ = useStacksHeight(network);
@@ -244,11 +246,17 @@ export default function MyWins() {
                 />
               ))}
             </div>
-            <motion.div className={`relative bg-white p-5 ${brutal} max-w-sm w-full mx-3 flex items-center gap-3`}
+            <motion.div className={`relative bg-white p-5 ${brutal} max-w-sm w-full mx-3`}
               initial={{ scale: 0.9, rotate: -2 }} animate={{ scale: 1, rotate: 0 }} transition={{ type: 'spring', stiffness: 300, damping: 20 }}>
-              <PartyPopper className="h-6 w-6"/>
-              <div className="text-lg font-black">Prize claimed!</div>
-              <button className={`${brutal} bg-zinc-200 px-2 py-1 ml-auto`} onClick={() => setCelebrate(false)}><X className="h-4 w-4"/></button>
+              <div className="flex items-center gap-3 mb-3">
+                <PartyPopper className="h-6 w-6"/>
+                <div className="text-lg font-black">Prize claimed!</div>
+                <button className={`${brutal} bg-zinc-200 px-2 py-1 ml-auto`} onClick={() => setCelebrate(false)}><X className="h-4 w-4"/></button>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-sm opacity-70">{lastClaimAmountStx ? `${lastClaimAmountStx} STX` : ''}</div>
+                <ShareButton type="win" data={{ amountStx: lastClaimAmountStx || undefined }} url={typeof window !== 'undefined' ? window.location.origin : undefined} />
+              </div>
             </motion.div>
           </motion.div>
         )}
@@ -265,10 +273,11 @@ export default function MyWins() {
           setClaimOpen(false);
           if (selected) {
             setWins((prev) => prev.map((w) => w.id === selected.id ? { ...w, claimed: true, claimable: false } : w));
+            try { setLastClaimAmountStx(microToStx(selected.netPrize)); } catch {}
           }
           setSelected(null);
           setCelebrate(true);
-          setTimeout(() => setCelebrate(false), 2500);
+          setTimeout(() => setCelebrate(false), 3000);
         }}
       />
     </div>

--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -3,13 +3,15 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Chess, type Move, type Square } from 'chess.js';
 import { Chessboard } from 'react-chessboard';
-import { Trophy, Clock, Users, Lightbulb, RotateCcw, FlagTriangleRight, Share2, X } from 'lucide-react';
+import { Trophy, Clock, Users, Lightbulb, RotateCcw, FlagTriangleRight, X } from 'lucide-react';
 import useWallet from '../hooks/useWallet';
 import { getPuzzlesByDifficulty, type Puzzle, hashSolution } from '../lib/puzzles-db';
 import { getPuzzleInfo, getLeaderboard, type LeaderboardEntry } from '../lib/contracts';
 import { getApiBaseUrl, microToStx, type NetworkName, getNetwork } from '../lib/stacks';
 import { fetchCallReadOnlyFunction, uintCV, standardPrincipalCV, ClarityType } from '@stacks/transactions';
 import { useSubmitSolution } from '../hooks/useContract';
+import ShareButton from '../components/ShareButton';
+import { formatSolveTime } from '../lib/time-utils';
 
 const brutal = 'rounded-none border-[3px] border-black shadow-[8px_8px_0_#000]';
 
@@ -483,13 +485,7 @@ export default function SolvePuzzle() {
                 </div>
               </div>
               <div className="flex items-center justify-between">
-                <a
-                  className={`${brutal} bg-blue-300 hover:bg-blue-400 px-3 py-2 inline-flex items-center gap-2`}
-                  href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(`I just solved a ${info?.difficulty} Stackmate puzzle in ${formatTime(totalTime)}! #Stacks #Chess`)}`}
-                  target="_blank" rel="noreferrer"
-                >
-                  <Share2 className="h-4 w-4"/> Share
-                </a>
+                <ShareButton type="solve" data={{ durationText: formatTime(totalTime) }} url={typeof window !== 'undefined' ? `${window.location.origin}/puzzle/${numericId}` : undefined} />
                 <button className={`${brutal} bg-green-300 hover:bg-green-400 px-3 py-2`} onClick={() => {
                   setSolved(false);
                   navigate('/');


### PR DESCRIPTION
Title: Add social sharing utilities and buttons; integrate into success screens

Summary
- Adds a reusable ShareButton component for Twitter/X and copy-to-clipboard sharing.
- Provides a share-utils module with common helpers.
- Integrates sharing into the Solve success modal and the My Wins “Prize claimed” celebration overlay.

Details
- New utils: src/lib/share-utils.ts
  - generateShareText(type, data): builds text for solve, win, or invite
  - shareToTwitter(text, url): opens Twitter intent
  - copyToClipboard(text): uses Clipboard API with fallback
- New component: src/components/ShareButton.tsx
  - Renders Tweet and Copy buttons with existing neo‑brutalist styling
  - Accepts type (solve | win | invite), optional data, and url
- Integrations
  - SolvePuzzle success modal: share “I just solved… in M:SS” with puzzle link
  - MyWins claimed overlay: share “I won X STX…” with site link

Example texts
- Solve: "I just solved a chess puzzle in 2:45! Think you can beat me? 🏆"
- Win: "I won 22.8 STX playing chess puzzles! 💰"
- Invite: "Join me solving chess puzzles for STX"

Notes
- Uses dynamic toasts (sonner / react-hot-toast fallback) after copying
- URL defaults to window.location.origin; puzzle link used when available


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ff4d8f00-70d1-4d8d-b09f-36e32962f612/task/9e52af76-1e14-4289-a6a4-4b5180159e13))