### PR TITLE
Fix: prevent false CLOSED; add LIVE badge on active puzzles

### DIFF
--- a/src/components/PuzzleCard.tsx
+++ b/src/components/PuzzleCard.tsx
@@ -183,6 +183,26 @@ export default function PuzzleCard({
               </span>
             </motion.div>
           )}
+          {!winner && !entered && isActive && (
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              style={{
+                background: colors.success,
+                border: `3px solid ${colors.border}`,
+                boxShadow: shadows.brutalSmall,
+                padding: '6px 12px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+              }}
+            >
+              <Zap className="h-4 w-4" style={{ color: colors.dark }} />
+              <span style={{ fontWeight: 900, fontSize: '12px', textTransform: 'uppercase', color: colors.dark }}>
+                LIVE
+              </span>
+            </motion.div>
+          )}
         </div>
       </div>
 
@@ -349,7 +369,7 @@ export default function PuzzleCard({
             fontSize: '14px',
             color: ended ? colors.white : colors.dark,
           }}>
-            {ended ? '00:00' : countdown}
+            {ended ? '00:00' : (countdown === '0s' ? 'LIVE' : countdown)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fix: prevent false "CLOSED" states when puzzle is active; add LIVE badge

Summary
- Use on-chain isActive (already in main) as the sole source for card CLOSED state.
- Add a prominent LIVE badge on active puzzles to reduce confusion.
- Avoid showing “ENDED 00:00” when isActive=true but countdown estimate reaches 0s; display LIVE instead.

Why
- Users reported seeing CLOSED even though the contract still shows the puzzle as active. This can happen when the local block-time estimate reaches 0 while the contract hasn’t been closed via set-winner yet.

Changes
- src/components/PuzzleCard.tsx
  - Added isActive-driven LIVE badge.
  - Timer tile now shows LIVE when countdown label is 0s but isActive=true.
  - CLOSED button state remains tied to isActive=false only.

Impact
- Enter button remains enabled as long as the contract reports active, preventing false-negative UI states.

Notes
- Enter will still fail on-chain if the deadline has truly passed (contract enforces it), which is correct. This change only fixes the premature CLOSED display.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/89ca7321-d460-418f-9120-3635e8c9aa88/task/8b9e9b5b-7b5a-4e0e-b0be-bfb52f80700a))