### PR TITLE
Lock app to testnet-only mode; add TESTNET badge

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { Trophy } from 'lucide-react';
+import { Trophy, Network } from 'lucide-react';
 import WalletConnect from './WalletConnect';
 import NotificationBell from './NotificationBell';
 import { colors, shadows } from '../styles/neo-brutal-theme';
@@ -9,33 +9,60 @@ import NeoButton from './neo/NeoButton';
 export default function Header() {
   return (
     <header className="flex items-center justify-between mb-10 sm:mb-16 flex-wrap gap-4">
-      <motion.div
-        initial={{ rotate: -2, x: -20, opacity: 0 }}
-        animate={{ rotate: 2, x: 0, opacity: 1 }}
-        transition={{ type: 'spring', stiffness: 300 }}
-        style={{
-          background: colors.primary,
-          border: `6px solid ${colors.border}`,
-          boxShadow: shadows.brutal,
-          padding: '16px 32px',
-        }}
-      >
-        <Link 
-          to="/" 
-          className="text-brutal" 
-          style={{ 
-            fontSize: 'clamp(24px, 5vw, 32px)', 
-            color: colors.dark, 
-            textDecoration: 'none',
-            fontFamily: "'Space Grotesk', sans-serif",
-            fontWeight: 900,
-            textTransform: 'uppercase',
-            letterSpacing: '-0.02em',
+      <div className="flex items-center gap-3">
+        <motion.div
+          initial={{ rotate: -2, x: -20, opacity: 0 }}
+          animate={{ rotate: 2, x: 0, opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 300 }}
+          style={{
+            background: colors.primary,
+            border: `6px solid ${colors.border}`,
+            boxShadow: shadows.brutal,
+            padding: '16px 32px',
           }}
         >
-          STACKMATE
-        </Link>
-      </motion.div>
+          <Link 
+            to="/" 
+            className="text-brutal" 
+            style={{ 
+              fontSize: 'clamp(24px, 5vw, 32px)', 
+              color: colors.dark, 
+              textDecoration: 'none',
+              fontFamily: "'Space Grotesk', sans-serif",
+              fontWeight: 900,
+              textTransform: 'uppercase',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            STACKMATE
+          </Link>
+        </motion.div>
+        
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 300, delay: 0.2 }}
+          style={{
+            background: colors.intermediate,
+            border: `4px solid ${colors.border}`,
+            boxShadow: shadows.brutalSmall,
+            padding: '8px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+          }}
+        >
+          <Network className="h-4 w-4" />
+          <span style={{ 
+            fontFamily: "'Space Grotesk', sans-serif",
+            fontWeight: 900, 
+            fontSize: '14px', 
+            textTransform: 'uppercase' 
+          }}>
+            TESTNET
+          </span>
+        </motion.div>
+      </div>
 
       <div className="flex items-center gap-3">
         <Link to="/leaderboard">

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -292,58 +292,30 @@ export default function WalletConnect({ className = '' }: { className?: string }
                   <LogOut className="h-4 w-4" /> DISCONNECT
                 </motion.button>
 
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
-                  <motion.button
-                    whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
-                    onClick={() => switchNetwork('testnet')}
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: '4px',
-                      padding: '12px',
-                      background: colors.intermediate,
-                      border: network === 'testnet' ? `6px solid ${colors.border}` : `4px solid ${colors.border}`,
-                      boxShadow: shadows.brutalSmall,
-                      cursor: 'pointer',
-                      fontWeight: 900,
-                      fontSize: '10px',
-                      textTransform: 'uppercase',
-                    }}
-                  >
+                <div style={{
+                  background: colors.intermediate,
+                  border: `4px solid ${colors.border}`,
+                  boxShadow: shadows.brutalSmall,
+                  padding: '12px',
+                  textAlign: 'center',
+                }}>
+                  <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px',
+                  }}>
                     <Network className="h-4 w-4" />
-                    TESTNET
-                  </motion.button>
-
-                  <motion.button
-                    whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
-                    onClick={() => switchNetwork('mainnet')}
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: '4px',
-                      padding: '12px',
-                      background: colors.accent3,
-                      border: network === 'mainnet' ? `6px solid ${colors.border}` : `4px solid ${colors.border}`,
-                      boxShadow: shadows.brutalSmall,
-                      cursor: 'pointer',
-                      fontWeight: 900,
-                      fontSize: '10px',
-                      textTransform: 'uppercase',
-                    }}
-                  >
-                    <Network className="h-4 w-4" />
-                    MAINNET
-                  </motion.button>
+                    <span style={{ fontWeight: 900, fontSize: '12px', textTransform: 'uppercase' }}>
+                      TESTNET ONLY
+                    </span>
+                  </div>
                 </div>
 
                 <motion.a
                   whileHover={{ x: -2, y: -2 }}
                   whileTap={{ scale: 0.98 }}
-                  href={`https://explorer.hiro.so/${network === 'testnet' ? 'testnet/' : ''}address/${address}?chain=stacks`}
+                  href={`https://explorer.hiro.so/testnet/address/${address}?chain=stacks`}
                   target="_blank"
                   rel="noreferrer"
                   style={{

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -188,7 +188,7 @@ async function getAddressFromProvider(network: NetworkName): Promise<string | nu
 }
 
 export const useWallet = create<WalletState>((set, get) => ({
-  network: 'testnet',
+  network: 'testnet', // LOCKED TO TESTNET
   providerId: null,
   address: null,
   balance: null,
@@ -253,25 +253,9 @@ export const useWallet = create<WalletState>((set, get) => ({
     set({ providerId: null, address: null, balance: null });
   },
   switchNetwork: async (network) => {
-    set({ network });
-    let addr = getAddressFromStorage(network) ?? (await getAddressFromProvider(network));
-    if (addr && !isValidAddress(addr)) {
-      console.error('[useWallet] Invalid address in switchNetwork:', addr);
-      addr = null;
-    }
-    set({ address: addr });
-
-    if (addr) {
-      try {
-        set({ isFetchingBalance: true });
-        const balance = await fetchStxBalance(addr, network);
-        set({ balance });
-      } finally {
-        set({ isFetchingBalance: false });
-      }
-    } else {
-      set({ balance: null });
-    }
+    // NETWORK LOCKED TO TESTNET - this function is a no-op now
+    console.log('[useWallet] Network switching disabled - app is locked to testnet');
+    return;
   },
   refresh: async () => {
     let addr = getAddressFromStorage(get().network) ?? (await getAddressFromProvider(get().network));

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { Trophy, Zap, Clock, Users, Coins, Crown, Target, Sparkles, Flame, Star } from 'lucide-react';
+import { Trophy, Zap, Clock, Users, Coins, Crown, Target, Sparkles, Flame, Star, Network } from 'lucide-react';
 import WalletConnect from '../components/WalletConnect';
 import NotificationBell from '../components/NotificationBell';
 import useWallet from '../hooks/useWallet';
@@ -221,21 +221,48 @@ export default function Home() {
       <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10">
         {/* Header */}
         <header className="flex items-center justify-between mb-10 sm:mb-16">
-          <motion.div
-            initial={{ rotate: -2, x: -20, opacity: 0 }}
-            animate={{ rotate: 2, x: 0, opacity: 1 }}
-            transition={{ type: 'spring', stiffness: 300 }}
-            style={{
-              background: colors.primary,
-              border: `6px solid ${colors.border}`,
-              boxShadow: shadows.brutal,
-              padding: '16px 32px',
-            }}
-          >
-            <Link to="/" className="text-brutal" style={{ fontSize: '32px', color: colors.dark, textDecoration: 'none' }}>
-              STACKMATE
-            </Link>
-          </motion.div>
+          <div className="flex items-center gap-3">
+            <motion.div
+              initial={{ rotate: -2, x: -20, opacity: 0 }}
+              animate={{ rotate: 2, x: 0, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 300 }}
+              style={{
+                background: colors.primary,
+                border: `6px solid ${colors.border}`,
+                boxShadow: shadows.brutal,
+                padding: '16px 32px',
+              }}
+            >
+              <Link to="/" className="text-brutal" style={{ fontSize: '32px', color: colors.dark, textDecoration: 'none' }}>
+                STACKMATE
+              </Link>
+            </motion.div>
+            
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ type: 'spring', stiffness: 300, delay: 0.2 }}
+              style={{
+                background: colors.intermediate,
+                border: `4px solid ${colors.border}`,
+                boxShadow: shadows.brutalSmall,
+                padding: '8px 16px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+              }}
+            >
+              <Network className="h-4 w-4" />
+              <span style={{ 
+                fontFamily: "'Space Grotesk', sans-serif",
+                fontWeight: 900, 
+                fontSize: '14px', 
+                textTransform: 'uppercase' 
+              }}>
+                TESTNET
+              </span>
+            </motion.div>
+          </div>
 
           <div className="flex items-center gap-3">
             <Link to="/leaderboard">


### PR DESCRIPTION
Lock app to testnet-only mode

Summary
- Remove network switcher from WalletConnect dropdown.
- Lock useWallet to testnet permanently; switchNetwork is now a no-op.
- Add visible TESTNET badge next to logo on all pages.

Why
- User requested testnet-only mode for development and testing phase.
- Simplifies UX by removing accidental mainnet switching.
- TESTNET badge makes the network always clear.

Changes
- src/hooks/useWallet.ts
  - Network locked to 'testnet' with comment.
  - switchNetwork function disabled (logs a message and returns).
  
- src/components/WalletConnect.tsx
  - Replaced network switcher buttons (Testnet/Mainnet) with a static "TESTNET ONLY" badge.
  - Explorer link always points to testnet.
  
- src/components/Header.tsx
  - Added TESTNET badge next to logo.
  
- src/pages/Home.tsx
  - Added TESTNET badge next to logo on Home page.

Impact
- Users cannot switch to mainnet from the UI.
- All wallet and contract calls use testnet.
- Clear visual indication of network on every page.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/89ca7321-d460-418f-9120-3635e8c9aa88/task/8b9e9b5b-7b5a-4e0e-b0be-bfb52f80700a))