### PR TITLE
Robust contract config: default to testnet puzzle-pool if env missing + reliable active puzzles

### DIFF
--- a/src/hooks/useBlockchain.ts
+++ b/src/hooks/useBlockchain.ts
@@ -5,7 +5,11 @@ import { getNetwork, type NetworkName, fetchStxBalance, type StxBalance } from '
 import useWallet from './useWallet';
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -26,7 +26,11 @@ interface MetaState {
 }
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -31,7 +31,11 @@ export interface PuzzleInfo {
 export interface LeaderboardEntry { player: string; solveTime: bigint; isCorrect: boolean; timestamp?: bigint; txId?: string }
 
 const getContractIds = (network: NetworkName): ContractIds => {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var (VITE_CONTRACT_TESTNET/VITE_CONTRACT_MAINNET) like SPXXXX.puzzle-pool');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,7 +19,11 @@ import NeoBadge from '../components/neo/NeoBadge';
 import { colors, shadows, animations, getRotation } from '../styles/neo-brutal-theme';
 
 function getContractIds(network: NetworkName) {
-  const id = (network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET) as string | undefined;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = (network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET) as string | undefined;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -14,7 +14,11 @@ import NeoBadge from '../components/neo/NeoBadge';
 import NeoInput from '../components/neo/NeoInput';
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/pages/MyWins.tsx
+++ b/src/pages/MyWins.tsx
@@ -25,7 +25,11 @@ type WinItem = {
 };
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -15,7 +15,11 @@ import NeoButton from '../components/neo/NeoButton'
 import NeoBadge from '../components/neo/NeoBadge'
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool'
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var')
   const [address, name] = id.split('.')
   return { address, name }

--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -754,7 +754,11 @@ export default function SolvePuzzle() {
 }
 
 function getContractIds(network: NetworkName) {
-  const id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
+  let id = network === 'testnet' ? (import.meta as any).env?.VITE_CONTRACT_TESTNET : (import.meta as any).env?.VITE_CONTRACT_MAINNET;
+  if (!id || typeof id !== 'string' || !id.includes('.')) {
+    if (network === 'testnet') id = DEFAULT_TESTNET;
+  }
   if (!id || typeof id !== 'string' || !id.includes('.')) throw new Error('Missing contract id env var');
   const [address, name] = id.split('.');
   return { address, name };


### PR DESCRIPTION
Fixes intermittent 'No active puzzles' when deployments lack VITE_CONTRACT_TESTNET.\n\n- Add default testnet contract id fallback in all getContractIds helpers (lib, hooks, pages).\n- Keep env override when provided.\n- Combined with prior change to use get-puzzle-info for activity, Home now lists active puzzles (e.g., #3) even without env set.\n\nThis makes preview/staging builds usable without manual env setup while keeping production configurable.