### PR TITLE
Fix: 'PUZZLE NOT FOUND' by normalizing on-chain difficulty strings

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,7 +16,7 @@ import PuzzleCardSkeleton from '../components/skeletons/PuzzleCardSkeleton';
 import NeoButton from '../components/neo/NeoButton';
 import NeoCard from '../components/neo/NeoCard';
 import NeoBadge from '../components/neo/NeoBadge';
-import { colors, shadows, animations, getRotation } from '../styles/neo-brutal-theme';
+import { colors, shadows, animations, getRotation, normalizeDifficulty } from '../styles/neo-brutal-theme';
 
 function getContractIds(network: NetworkName) {
   const DEFAULT_TESTNET = 'ST2QK4128H22NH4H8MD2AVP72M0Q72TKS48VB5469.puzzle-pool';
@@ -84,7 +84,7 @@ export default function Home() {
   }, [activeIds, infoQueries]);
 
   const byDifficulty = useMemo(() => {
-    const pick = (d: string) => pairs.find((p) => (p.info.difficulty || '').toLowerCase() === d) || null;
+    const pick = (d: string) => pairs.find((p) => normalizeDifficulty(p.info.difficulty || '') === d) || null;
     return {
       beginner: pick('beginner'),
       intermediate: pick('intermediate'),
@@ -567,7 +567,7 @@ export default function Home() {
             {allActive.map((p, idx) => {
               const info = p.info;
               const entered = Boolean(allEntryQueries[idx]?.data);
-              const dKey = (info.difficulty || '').toLowerCase() as 'beginner'|'intermediate'|'expert';
+              const dKey = normalizeDifficulty(info.difficulty || '') as 'beginner'|'intermediate'|'expert';
               return (
                 <NeoCard key={p.id} rotate={getRotation(idx)} hoverable>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px', gap: '12px' }}>

--- a/src/pages/Puzzle.tsx
+++ b/src/pages/Puzzle.tsx
@@ -8,7 +8,7 @@ import { getPuzzlesByDifficulty, type Puzzle } from '../lib/puzzles-db';
 import { useQuery } from '@tanstack/react-query';
 import { getPuzzleInfo, type PuzzleInfo } from '../lib/contracts';
 import Header from '../components/Header';
-import { colors, shadows, getDifficultyColor } from '../styles/neo-brutal-theme';
+import { colors, shadows, getDifficultyColor, normalizeDifficulty } from '../styles/neo-brutal-theme';
 import NeoButton from '../components/neo/NeoButton';
 import NeoBadge from '../components/neo/NeoBadge';
 import { microToStx } from '../lib/stacks';
@@ -29,14 +29,14 @@ export default function PuzzlePage() {
 
   const chosen = useMemo(() => {
     if (!info) return null as Puzzle | null;
-    const d = (info.difficulty || '').toLowerCase();
-    const list = getPuzzlesByDifficulty((d as any) || 'beginner');
+    const nd = normalizeDifficulty(info.difficulty || 'beginner');
+    const list = getPuzzlesByDifficulty(nd as any);
     if (!list.length) return null;
     const idx = Math.abs((numericId || 1) - 1) % list.length;
     return list[idx];
   }, [info, numericId]);
 
-  const difficultyColor = getDifficultyColor(info?.difficulty?.toLowerCase() as any);
+  const difficultyColor = getDifficultyColor((info?.difficulty || '') as any);
 
   return (
     <div style={{ minHeight: '100vh', background: colors.light, position: 'relative', overflow: 'hidden' }}>

--- a/src/styles/neo-brutal-theme.ts
+++ b/src/styles/neo-brutal-theme.ts
@@ -173,15 +173,23 @@ export function getRotation(index: number): number {
   return rotations[index % rotations.length];
 }
 
+export function normalizeDifficulty(difficulty: string): 'beginner' | 'intermediate' | 'expert' {
+  const raw = (difficulty || '').toString().toLowerCase().trim();
+  const unquoted = raw.replace(/^['"]+|['"]+$/g, '');
+  if (unquoted === 'intermediate') return 'intermediate';
+  if (unquoted === 'expert') return 'expert';
+  return 'beginner';
+}
+
 export function getDifficultyColor(difficulty: string): string {
-  const d = difficulty.toLowerCase();
+  const d = normalizeDifficulty(difficulty);
   if (d === 'intermediate') return colors.intermediate;
   if (d === 'expert') return colors.expert;
   return colors.beginner;
 }
 
 export function getDifficultyGradient(difficulty: string): string {
-  const d = difficulty.toLowerCase();
+  const d = normalizeDifficulty(difficulty);
   if (d === 'intermediate') return gradients.intermediate;
   if (d === 'expert') return gradients.expert;
   return gradients.beginner;


### PR DESCRIPTION
Some create-puzzle calls saved difficulty with quotes (e.g., "expert").\nThis caused local puzzle selection to fail and the UI showed 'PUZZLE NOT FOUND'.\n\n- Add normalizeDifficulty() to strip quotes/whitespace and lower-case\n- Use normalized values in Home (difficulty selection), Puzzle page (puzzle database mapping), and all color/gradient helpers\n- Works with beginner/intermediate/expert regardless of extra quotes\n\nThis unblocks Puzzle #3 rendering locally.