### PR TITLE
Fix: Ensure Enter Puzzle modal appears (portal + high z-index)

### DIFF
--- a/src/components/EnterPuzzleModal.tsx
+++ b/src/components/EnterPuzzleModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { AlertTriangle, Coins, Loader2, Shield, Wallet, X, Zap } from 'lucide-react';
 import { microToStx } from '../lib/stacks';
@@ -109,14 +110,15 @@ export default function EnterPuzzleModal({ isOpen, onClose, puzzleId, difficulty
 
   const diffColor = getDifficultyColor(difficulty);
 
-  return (
+  return createPortal(
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          className="fixed inset-0 flex items-center justify-center p-4"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
+          style={{ zIndex: 9999 }}
         >
           <div 
             className="absolute inset-0 bg-black/70 backdrop-blur-sm" 
@@ -421,6 +423,7 @@ export default function EnterPuzzleModal({ isOpen, onClose, puzzleId, difficulty
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }


### PR DESCRIPTION
Problem:\nSome users could not see the Enter Puzzle modal after clicking Enter due to stacking context/z-index conflicts from surrounding layout elements.\n\nFix:\n- Render EnterPuzzleModal via a portal into document.body to escape local stacking contexts.\n- Add explicit inline z-index (9999) on the fixed overlay container to guarantee it sits above page content regardless of Tailwind utility availability.\n\nNotes:\n- No behavior changes to the modal flow; this only ensures visibility.\n- Works alongside existing Tailwind classes and animations.\n\nTest plan:\n- Click Enter on Home (both featured difficulties and All Active Puzzles sections).\n- Verify the modal appears above all content and can be dismissed.\n- Confirm the Confirm Entry flow still triggers wallet signature.