### PR TITLE
Dev: Fix CORS by proxying Hiro API via Vite and using proxied base URL in dev

### DIFF
--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -25,7 +25,13 @@ export const NETWORKS: Record<NetworkName, NetworkConfig> = {
 };
 
 export const getNetwork = (name: NetworkName): StacksNetwork => NETWORKS[name].network;
-export const getApiBaseUrl = (name: NetworkName): string => NETWORKS[name].apiBaseUrl;
+export const getApiBaseUrl = (name: NetworkName): string => {
+  const isDev = typeof window !== 'undefined' && (import.meta as any).env?.DEV;
+  if (isDev) {
+    return name === 'testnet' ? '/hiro' : '/hiro-mainnet';
+  }
+  return NETWORKS[name].apiBaseUrl;
+};
 
 export const getExplorerAddressUrl = (name: NetworkName, address: string) =>
   `${NETWORKS[name].explorerBaseUrl}/address/${address}?chain=stacks`;

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -24,7 +24,14 @@ export const NETWORKS: Record<NetworkName, NetworkConfig> = {
   },
 };
 
-export const getNetwork = (name: NetworkName): StacksNetwork => NETWORKS[name].network;
+export const getNetwork = (name: NetworkName): StacksNetwork => {
+  const n = NETWORKS[name].network;
+  const isDev = typeof window !== 'undefined' && (import.meta as any).env?.DEV;
+  if (isDev) {
+    (n as any).coreApiUrl = name === 'testnet' ? '/hiro' : '/hiro-mainnet';
+  }
+  return n;
+};
 export const getApiBaseUrl = (name: NetworkName): string => {
   const isDev = typeof window !== 'undefined' && (import.meta as any).env?.DEV;
   if (isDev) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,20 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/hiro': {
+        target: 'https://api.testnet.hiro.so',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/hiro/, ''),
+      },
+      '/hiro-mainnet': {
+        target: 'https://api.hiro.so',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/hiro-mainnet/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
Problem:\nBrowser CORS blocks direct calls from http://localhost:5173 to https://api.testnet.hiro.so (No Access-Control-Allow-Origin).\n\nFix:\n- Add Vite dev server proxy for /hiro (testnet) and /hiro-mainnet (mainnet), rewriting to Hiro base URLs.\n- Make getApiBaseUrl return proxied paths in dev so all existing fetches route through the proxy automatically.\n\nFiles:\n- vite.config.ts: server.proxy config for /hiro and /hiro-mainnet with rewrite.\n- src/lib/stacks.ts: getApiBaseUrl returns '/hiro' or '/hiro-mainnet' when import.meta.env.DEV is true.\n\nImpact:\n- Local development no longer hits CORS errors when fetching balances or /v2/info.\n- No changes to production behavior; it still uses the public Hiro endpoints.\n\nTest plan:\n- Run dev server and load Home; calls to /v2/info and balances should go through /hiro and succeed without CORS errors.