### PR TITLE
Fix: Complete CORS proxy + 429 rate limit mitigation

### DIFF
--- a/src/hooks/useBlockchain.ts
+++ b/src/hooks/useBlockchain.ts
@@ -110,7 +110,8 @@ export function useUserBalance(address?: string) {
       return fetchStxBalance(addr, network);
     },
     enabled: !!addr,
-    refetchInterval: 10000,
+    refetchInterval: 60000,
+    staleTime: 45000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -321,7 +321,7 @@ export default function useNotifications() {
     };
 
     run();
-    id = setInterval(run, 30_000);
+    id = setInterval(run, 60_000);
 
     const onVis = () => { if (!stopped && document.visibilityState === 'visible') run(); };
     document.addEventListener('visibilitychange', onVis);

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,57 @@
+// Fetch wrapper with retry and backoff for Hiro API calls
+
+interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+}
+
+const defaultRetryOptions: Required<RetryOptions> = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 10000,
+  backoffFactor: 2,
+};
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchWithRetry(
+  url: string,
+  init?: RequestInit,
+  options: RetryOptions = {}
+): Promise<Response> {
+  const opts = { ...defaultRetryOptions, ...options };
+  let lastError: Error | null = null;
+  let delay = opts.initialDelayMs;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, init);
+      
+      // 429 (rate limit) or 5xx (server error) - retry
+      if (res.status === 429 || res.status >= 500) {
+        if (attempt < opts.maxRetries) {
+          console.warn(`[fetchWithRetry] ${res.status} on ${url}, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`);
+          await sleep(delay);
+          delay = Math.min(delay * opts.backoffFactor, opts.maxDelayMs);
+          continue;
+        }
+      }
+      
+      return res;
+    } catch (err: any) {
+      lastError = err;
+      if (attempt < opts.maxRetries) {
+        console.warn(`[fetchWithRetry] Network error on ${url}, retrying in ${delay}ms (attempt ${attempt + 1}/${opts.maxRetries})`, err);
+        await sleep(delay);
+        delay = Math.min(delay * opts.backoffFactor, opts.maxDelayMs);
+        continue;
+      }
+    }
+  }
+
+  throw lastError || new Error(`Failed to fetch ${url} after ${opts.maxRetries} retries`);
+}


### PR DESCRIPTION
## Problem

After merging PR #52's initial CORS proxy setup, testing revealed:

1. **Proxy still not working** - The earlier fix attempted to mutate singleton `STACKS_MAINNET`/`STACKS_TESTNET` objects, but `@stacks/transactions`' `fetchCallReadOnlyFunction` didn't pick up the changes and continued hitting the public API directly, causing CORS errors.

2. **429 Rate Limiting** - Aggressive polling intervals caused "Too Many Requests" errors:
   - Balance: every 10 seconds
   - Notifications: every 30 seconds  
   - Multiple components hitting the same endpoints simultaneously

## Solution

### CORS Proxy (Complete Fix)
- **Root cause**: Cannot mutate frozen singleton network objects
- **Fix**: Create fresh `StacksTestnet`/`StacksMainnet` instances with explicit `url` parameter pointing to the full proxy URL (`http://localhost:5173/hiro`)
- This ensures `@stacks/transactions` routes ALL read-only contract calls through the Vite proxy

### Rate Limit Mitigation
- **New utility**: `src/lib/api-client.ts` with `fetchWithRetry` function
  - Exponential backoff for 429/5xx responses  
  - Configurable max retries (default 3), initial delay (1s), max delay (10s)
  - Logs retry attempts to console for debugging
- **Polling interval increases**:
  - Balance: 10s → 60s (added `staleTime: 45000ms`)
  - Notifications: 30s → 60s
- **Applied retry wrapper** to `fetchStxBalance`

## Files Changed

### New
- **src/lib/api-client.ts**: Retry/backoff utility for fetch requests

### Modified
- **src/lib/stacks.ts**:
  - Import `StacksMainnet`/`StacksTestnet` classes instead of singletons
  - `getNetwork()` creates fresh instances with `{ url: 'http://localhost:5173/hiro' }` in dev
  - `getApiBaseUrl()` returns `/hiro` or `/hiro-mainnet` in dev  
  - `fetchStxBalance()` uses `fetchWithRetry`
  
- **src/hooks/useBlockchain.ts**:
  - `useUserBalance`: interval 10s → 60s, added `staleTime: 45000ms`
  
- **src/hooks/useNotifications.ts**:
  - Notification polling: interval 30s → 60s

## Impact

- **CORS**: All API calls (including read-only contract calls) now route through Vite proxy in dev → no more CORS errors
- **Rate Limiting**: Reduced request frequency + automatic retry with backoff → no more 429 errors under normal usage
- **Production**: No changes; still uses public Hiro endpoints directly

## How to Test

1. **Restart dev server** (required for Vite proxy config from PR #52 + these network instance changes)
2. Open DevTools Network tab
3. Verify:
   - Requests to `/hiro/v2/contracts/call-read/...` instead of `https://api.testnet.hiro.so/...`
   - No CORS errors in console
   - No 429 errors during normal browsing
4. Check polling behavior:
   - Balance updates ~every 60s
   - Notifications poll ~every 60s

## Dependencies

- Requires PR #52 (Vite proxy config) to be merged first


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/94ff2521-bdcf-4cca-a171-9e1ef1468b74/task/e2308c3c-2c55-41f0-b37e-f47a79561e27))