### PR TITLE
Fix: Global fetch interceptor to force CORS proxy in dev

### DIFF
--- a/src/lib/fetch-intercept.ts
+++ b/src/lib/fetch-intercept.ts
@@ -1,0 +1,45 @@
+// Global fetch interceptor for dev mode to route all Hiro API calls through Vite proxy
+
+const originalFetch = window.fetch;
+
+const isDev = import.meta.env.DEV;
+
+if (isDev) {
+  window.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    let url: string;
+    
+    if (typeof input === 'string') {
+      url = input;
+    } else if (input instanceof URL) {
+      url = input.toString();
+    } else if (input instanceof Request) {
+      url = input.url;
+    } else {
+      url = String(input);
+    }
+
+    // Intercept Hiro API calls and route through proxy
+    if (url.includes('api.testnet.hiro.so')) {
+      url = url.replace('https://api.testnet.hiro.so', '/hiro');
+      console.log('[fetch-intercept] Proxying testnet request:', url);
+    } else if (url.includes('api.hiro.so') && !url.includes('testnet')) {
+      url = url.replace('https://api.hiro.so', '/hiro-mainnet');
+      console.log('[fetch-intercept] Proxying mainnet request:', url);
+    }
+
+    // Call original fetch with modified URL
+    if (typeof input === 'string') {
+      return originalFetch(url, init);
+    } else if (input instanceof URL) {
+      return originalFetch(new URL(url), init);
+    } else if (input instanceof Request) {
+      return originalFetch(new Request(url, input), init);
+    }
+    
+    return originalFetch(url, init);
+  };
+
+  console.log('[fetch-intercept] Dev mode: Hiro API calls will be proxied through Vite');
+}
+
+export {};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './lib/fetch-intercept'
 import './index.css'
 import App from './App.tsx'
 


### PR DESCRIPTION
## Problem\n\nDespite PR #53 and #54's attempts to route Hiro API calls through Vite proxy, requests still go directly to https://api.testnet.hiro.so causing CORS errors. The @stacks/transactions library was ignoring our endpoint overrides.\n\n## Solution\n\nIntercept window.fetch globally in dev mode to rewrite URLs at the browser level before requests go out.\n\n**New file**: src/lib/fetch-intercept.ts\n- Rewrites https://api.testnet.hiro.so → /hiro\n- Rewrites https://api.hiro.so → /hiro-mainnet\n- Logs every intercepted request\n- Only runs in dev mode (import.meta.env.DEV)\n\n**Updated**: src/main.tsx\n- Imports interceptor at the very start before React loads\n\n## Why This Works\n\nPrevious approaches tried to override network configuration, but @stacks/transactions constructed URLs internally using hardcoded endpoints. This interceptor catches ALL fetch calls at the browser level regardless of how the URL was constructed.\n\n## Impact\n\n- ✅ All API calls route through Vite proxy in dev\n- ✅ No more CORS errors\n- ✅ Reduces 429 rate limits (combined with retry from PR #53)\n- ✅ Zero production impact (dev mode only)\n\n## Test\n\n1. Restart dev server\n2. Open console\n3. Should see: [fetch-intercept] Dev mode: Hiro API calls will be proxied through Vite\n4. Network tab shows requests to /hiro/... not https://api.testnet.hiro.so/...\n5. No CORS errors