### PR TITLE
Fix: React Hooks violation in TransactionStatus component

### DIFF
--- a/src/components/TransactionStatus.tsx
+++ b/src/components/TransactionStatus.tsx
@@ -9,6 +9,7 @@ const brutal = 'rounded-none border-[3px] border-black shadow-[6px_6px_0_#000]';
 export default function TransactionStatus() {
   const { items } = useTransaction();
   const dismiss = useTxStore((s) => s.remove);
+  const { network } = useWallet();
   const current = useMemo(() => {
     // Prefer active; otherwise show most recent non-idle
     const active = items.find((x) => x.status === 'pending' || x.status === 'confirming');
@@ -24,8 +25,6 @@ export default function TransactionStatus() {
   }, [autoDismiss, current]);
 
   if (!current) return null;
-
-  const { network } = useWallet();
   const url = current.url || explorerTxUrl(network, current.txId);
 
   const statusText =


### PR DESCRIPTION
Fixes the 'Rendered more hooks than during the previous render' error by moving the useWallet() hook call before the conditional return statement.

The issue was causing the app to crash when clicking the 'Confirm Entry' button to stake STX for puzzle entry.

Changes:
- Moved useWallet() hook to the top of the component to ensure hooks are called in consistent order
- This ensures React's Rules of Hooks are followed