### PR TITLE
Prefer openContractCall first for Leather providers

### DIFF
--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -182,14 +182,24 @@ const requestContractCall = async (params: any): Promise<{ txId?: string; error?
     return null;
   }
 
-  const attempts: Array<[string, 'two-arg' | 'object']> = [
-    ['stx_callContract', 'two-arg'],
-    ['stx_callContract', 'object'],
-    ['stx_contractCall', 'object'],
-    ['stx_makeContractCall', 'object'],
-    ['contract_call', 'object'],
-    ['openContractCall', 'object'],
-  ];
+  const preferOpen = !!(globalThis as any)?.LeatherProvider;
+  const attempts: Array<[string, 'two-arg' | 'object']> = preferOpen
+    ? [
+        ['openContractCall', 'object'],
+        ['contract_call', 'object'],
+        ['stx_callContract', 'two-arg'],
+        ['stx_callContract', 'object'],
+        ['stx_contractCall', 'object'],
+        ['stx_makeContractCall', 'object'],
+      ]
+    : [
+        ['stx_callContract', 'two-arg'],
+        ['stx_callContract', 'object'],
+        ['stx_contractCall', 'object'],
+        ['stx_makeContractCall', 'object'],
+        ['contract_call', 'object'],
+        ['openContractCall', 'object'],
+      ];
 
   for (const [m, style] of attempts) {
     const r = await tryCall(m, style);


### PR DESCRIPTION
# Prefer openContractCall for Leather providers

## Summary
Leather popup still reported `Not a serialized post condition` even with hex-encoded PCs. This PR prioritizes `openContractCall` when Leather is detected, which accepts typed post condition objects and avoids RPC wire-format inconsistencies.

## Changes
- Detect Leather via `globalThis.LeatherProvider`
- Attempt order for Leather:
  1. `openContractCall`
  2. `contract_call`
  3. `stx_callContract` (two-arg)
  4. `stx_callContract` (object)
  5. `stx_contractCall`
  6. `stx_makeContractCall`
- Non‑Leather providers keep previous order.
- Keep param shaping:
  - Hex PCs for `stx_*` methods
  - Typed PCs for `openContractCall/contract_call`
  - `postConditionMode`: "deny" string

## Verification
- TypeScript passes
- Console now shows `openContractCall` as first attempt when Leather is present

## Notes
If a provider still rejects, we can drop to @stacks/connect's `openContractCall` helper next.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/db003005-fef7-4fef-83e1-26cf95b3d1d5/task/a3687f18-0a05-46fb-961c-3cbe6e61331b))