### PR TITLE
Fix: Force chess board to re-render with correct FEN

### DIFF
--- a/src/components/ChessPuzzleSolver.tsx
+++ b/src/components/ChessPuzzleSolver.tsx
@@ -33,6 +33,11 @@ function pad(n: number) { return n < 10 ? `0${n}` : `${n}`; }
 export default function ChessPuzzleSolver({ puzzleId, fen, solution, onSolve }: ChessPuzzleSolverProps) {
   const [game, setGame] = useState(() => new Chess(fen));
   const [boardFen, setBoardFen] = useState(fen);
+  const renderFen = useMemo(() => {
+    const f = boardFen || fen || 'start';
+    try { new Chess(f); } catch { return 'start'; }
+    return f;
+  }, [boardFen, fen]);
   const [index, setIndex] = useState(0);
   const [history, setHistory] = useState<string[]>([]);
   const [lastMove, setLastMove] = useState<{ from: Square; to: Square } | null>(null);
@@ -270,8 +275,9 @@ export default function ChessPuzzleSolver({ puzzleId, fen, solution, onSolve }: 
 
         {/* Chess Board */}
         <Chessboard
+          key={`board-${puzzleId}-${renderFen}`}
           {...({
-            position: boardFen,
+            position: renderFen,
             onPieceDrop: onDrop,
             customBoardStyle: boardStyle,
             customDarkSquareStyle: { backgroundColor: customDark },

--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -55,6 +55,11 @@ export default function SolvePuzzle() {
 
   const [game, setGame] = useState<Chess | null>(null);
   const [boardFen, setBoardFen] = useState<string | null>(null);
+  const renderFen = useMemo(() => {
+    const f = boardFen || localPuzzle?.fen || 'start';
+    try { new Chess(f); } catch { return 'start'; }
+    return f;
+  }, [boardFen, localPuzzle?.fen]);
   const [index, setIndex] = useState(0);
   const [history, setHistory] = useState<string[]>([]);
   const [lastMove, setLastMove] = useState<{ from: Square; to: Square } | null>(null);
@@ -419,8 +424,7 @@ export default function SolvePuzzle() {
                 </div>
 
                 {/* Chess Board */}
-                {!boardFen || !localPuzzle ? (
-                  <div style={{ 
+                {!renderFen || renderFen === 'start' || !localPuzzle ? (                  <div style={{ 
                     aspectRatio: '1', 
                     background: colors.accent, 
                     border: `6px solid ${colors.border}`,
@@ -435,8 +439,9 @@ export default function SolvePuzzle() {
                   </div>
                 ) : (
                   <Chessboard
+                    key={`board-${numericId}-${renderFen}`}
                     {...({
-                      position: boardFen,
+                      position: renderFen,
                       onPieceDrop: onDrop,
                       customBoardStyle: boardStyle,
                       customDarkSquareStyle: { backgroundColor: customDark },


### PR DESCRIPTION
## Fix: Force chess board to re-render with correct FEN

Some users still saw the **starting position** and couldn't drop pieces even after PR #76. This PR strengthens the board rendering logic so it always shows the correct puzzle FEN and re-renders reliably.

### Problem
- Board sometimes mounted before FEN was ready
- React-chessboard didn't re-render when state changed due to stale mount
- Users could drag but not drop because moves were illegal from starting position

### Solution
- Introduced `renderFen` memo that selects the best available FEN: `boardFen || puzzle.fen || 'start'`
- Added `key` prop on Chessboard (`key={boardId}-${renderFen}`) to force remount when FEN changes
- Show a "LOADING BOARD..." placeholder until a valid FEN is ready
- Applied fix to both `SolvePuzzle.tsx` and `ChessPuzzleSolver.tsx`

### Files Changed
- `src/pages/SolvePuzzle.tsx`
- `src/components/ChessPuzzleSolver.tsx`

### Testing
- [x] Board shows correct mid-game position for Beginner #1 and Intermediate #2
- [x] Pieces drag and drop correctly
- [x] Wrong moves rejected (board shakes)
- [x] Reloading page preserves correct board

This ensures the puzzle is always in the right state before user interaction.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/5527d05e-932c-4ee9-871b-7f72ed1bce00/task/ad05d6af-056a-49b4-8917-729df439a81f))