### PR TITLE
Normalize SAN comparison and add onDrop diagnostics

### DIFF
--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -254,11 +254,14 @@ export default function SolvePuzzle() {
   }, [index, localPuzzle?.solution?.length]);
 
   const onDrop = useCallback((sourceSquare: Square, targetSquare: Square) => {
+    console.log('[SolvePuzzle] onDrop called:', { sourceSquare, targetSquare, solved, hasGame: !!game, index, expected: localPuzzle?.solution?.[index] });
     if (solved || !game || !localPuzzle) return false;
     const g = new Chess(game.fen());
     const legal = g.moves({ verbose: true }) as Move[];
     const candidates = legal.filter((m) => m.from === sourceSquare && m.to === targetSquare);
+    console.log('[SolvePuzzle] onDrop legal moves count:', legal.length, 'candidates:', candidates);
     if (candidates.length === 0) {
+      console.warn('[SolvePuzzle] No legal move for drop');
       setWrongShakeKey((k) => k + 1);
       return false;
     }
@@ -266,11 +269,15 @@ export default function SolvePuzzle() {
     const expected = localPuzzle.solution[index];
     const made = g.move({ from: mv.from, to: mv.to, promotion: mv.promotion });
     if (!made) {
+      console.warn('[SolvePuzzle] g.move failed for candidate:', mv);
       setWrongShakeKey((k) => k + 1);
       return false;
     }
     const san = made.san;
-    if (san !== expected) {
+    const normalize = (s: string) => s.replace(/[+#]+$/g, '');
+    const ok = normalize(san) === normalize(expected);
+    console.log('[SolvePuzzle] Move made:', { san, expected, ok, normalizedSan: normalize(san), normalizedExpected: normalize(expected) });
+    if (!ok) {
       setWrongShakeKey((k) => k + 1);
       return false;
     }


### PR DESCRIPTION
## Improve move matching and diagnostics

### Changes
- Normalize SAN comparison by ignoring trailing `+`/`#` in SAN strings.
- Add detailed `onDrop` logging to diagnose drag-and-drop issues (logs candidate moves, expected vs actual SAN, and reasons for rejection).

### Why
Some puzzles may include or omit check/checkmate suffixes inconsistently. The strict SAN equality caused correct moves (e.g., `Qh7` vs `Qh7+`) to be rejected. This update makes puzzle validation robust without allowing incorrect captures (we do not strip `x`).

### Impact
- Correct moves that result in check will no longer be rejected due to missing `+` in the dataset.
- Easier diagnosis if users report "can't move"—we'll see whether drops are firing and why they're rejected.

### Safety
- Only trailing `+`/`#` are ignored. Captures (`x`) and disambiguation remain required.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/7a445de2-43b2-458d-a3e0-d31ffd86d342/task/c21fba0b-24c9-45c5-affd-8d07385710fe))