### PR TITLE
fix(chess): enable correct-side dragging; pass typecheck

### DIFF
--- a/src/components/ChessPuzzleSolver.tsx
+++ b/src/components/ChessPuzzleSolver.tsx
@@ -279,6 +279,10 @@ export default function ChessPuzzleSolver({ puzzleId, fen, solution, onSolve }: 
           {...({
             position: renderFen,
             onPieceDrop: onDrop,
+            isDraggablePiece: ({ piece }: any) => {
+              const turn = new Chess(game.fen()).turn();
+              return piece?.startsWith(turn);
+            },
             customBoardStyle: boardStyle,
             customDarkSquareStyle: { backgroundColor: customDark },
             customLightSquareStyle: { backgroundColor: customLight },

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -237,7 +237,7 @@ export async function enterPuzzle({ puzzleId, entryFee, sender, network, onStatu
         network: getNetwork(network),
         onFinish: (data) => {
           console.log('[enterPuzzle] Transaction finished:', data);
-          const tid = data?.txId || (data as any)?.transaction?.txid || data?.txid;
+          const tid = data?.txId || (data as any)?.transaction?.txid || (data as any)?.txid;
           if (tid) {
             resolve(tid);
           } else {

--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -554,12 +554,17 @@ export default function SolvePuzzle() {
                     </div>
                   ) : (
                     <div key={`chessboard-${numericId}-${renderFen.substring(0, 20)}`}>
-                      {console.log('[SolvePuzzle] Rendering Chessboard with position:', renderFen, 'boardSize:', boardSize)}
+
                       <Chessboard
-                        id={`board-${numericId}`}
+
                         position={renderFen}
                         onPieceDrop={onDrop}
                         onSquareClick={onSquareClick as any}
+                        isDraggablePiece={({ piece }: any) => {
+                          if (!game) return false;
+                          const turn = new Chess(game.fen()).turn();
+                          return piece?.startsWith(turn);
+                        }}
                         arePiecesDraggable={true}
                         customBoardStyle={boardStyle}
                         customDarkSquareStyle={{ backgroundColor: customDark }}


### PR DESCRIPTION
Summary
- Fixes non-movable pieces by enabling drag for the current side to move (derived from FEN) so puzzles that begin with Black-to-move work as expected.
- Resolves minor typecheck issues encountered after enabling the drag guard (removed unsupported Chessboard prop, trimmed JSX console output, normalized tx id access).

Nature of change
- Bug fix: interaction/movement on puzzle boards.

Impact
- Users can now drag pieces immediately regardless of which color is to move at puzzle start.
- No UI changes beyond expected ability to drag the correct side.
- Typecheck is green; ESLint has existing repo-wide issues outside this fix. I kept scope limited to the touched files to keep the PR focused.

Why
- Puzzles frequently start with a specific side to move; without checking the actual turn, the board appeared unresponsive for half of scenarios.

Follow-ups (optional)
- Decide whether to address ESLint repository-wide or ignore legacy *.old.tsx files to reduce noise.
- Optionally auto-orient the board to the side-to-move and add a user toggle.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/4a9da025-f29f-45fb-af82-0a0e951e3062/task/eb222d31-dfdc-432c-8335-899a91f67ea4))