### PR TITLE
Fix chess piece drop by removing board rotation; improve DnD reliability

### DIFF
--- a/src/components/ChessgroundBoard.tsx
+++ b/src/components/ChessgroundBoard.tsx
@@ -48,6 +48,7 @@ export default function ChessgroundBoard({
         free: false,
         color: turnColor || 'white',
         dests: new Map(),
+        showDests: true,
       },
       events: {
         move: (orig, dest) => {
@@ -85,6 +86,7 @@ export default function ChessgroundBoard({
         free: movable?.free ?? false,
         color: turnColor || movable?.color || 'white',
         dests: movable?.dests || new Map(),
+        showDests: true,
       },
     };
 
@@ -105,6 +107,7 @@ export default function ChessgroundBoard({
       style={{
         width: '100%',
         aspectRatio: '1',
+        touchAction: 'none',
       }}
     />
   );

--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -414,8 +414,8 @@ export default function SolvePuzzle() {
             {/* Board Section */}
             <div ref={boardWrapRef}>
               <motion.div
-                initial={{ rotate: -1, y: 20, opacity: 0 }}
-                animate={{ rotate: -1, y: 0, opacity: 1 }}
+                initial={{ rotate: 0, y: 20, opacity: 0 }}
+                animate={{ rotate: 0, y: 0, opacity: 1 }}
                 transition={{ type: 'spring', stiffness: 300 }}
                 style={{
                   padding: '20px',


### PR DESCRIPTION
## Fix: Chess piece drops not registering

### Root Cause
Applying a CSS rotation transform to the board container (`rotate: -1`) interfered with Chessground's pointer-to-square mapping. This causes drops to be rejected because the calculated destination square doesn't line up with the pointer position.

### Changes
- Removed rotation on the board wrapper so the board isn't transformed
- Enabled `showDests` to visualize legal moves for easier testing
- Added `touchAction: none` on the board root for better touch/pointer handling on mobile
- Kept consolidated Chessground config updates to ensure FEN and legal dests stay in sync

### Files
- `src/pages/SolvePuzzle.tsx` — remove rotation on the board container
- `src/components/ChessgroundBoard.tsx` — add `showDests` and `touchAction: 'none'`

### Testing
- Pieces now drop correctly on valid squares (mouse and touch)
- Illegal drops snap back as expected
- Legal moves are highlighted on pick-up (blue dots)
- Board remains perfectly playable and responsive

### Notes
This directly addresses the "drags but doesn't drop where I want it to" report and is safe for MVP. The rest of the brutalist styling remains unchanged; only the board's container loses rotation to guarantee correct interaction math.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ec798605-ebab-4ed5-b942-fa7d173f63f3/task/2696ffac-5942-491c-82e7-5b25bc1d0aba))