### PR TITLE
Add Demo Mode toggle on Solve page

### DIFF
--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -51,18 +51,36 @@ export default function SolvePuzzle() {
   const submittedRef = useRef(false);
 
   const [elapsed, setElapsed] = useState(0);
-  const demoMode = useMemo(() => {
+  const [demoMode, setDemoMode] = useState<boolean>(() => {
     try {
       const params = new URLSearchParams(location.search);
       const v = (params.get('demo') || '').toLowerCase();
-      if (['1', 'true', 'win', 'yes'].includes(v)) return true;
+      if (['1', 'true', 'win', 'yes', 'on'].includes(v)) return true;
       if (typeof window !== 'undefined') {
         const ls = (window.localStorage.getItem('STACKMATE_DEMO_WIN_FIRST') || '').toLowerCase();
-        if (['1', 'true', 'win', 'yes'].includes(ls)) return true;
+        if (['1', 'true', 'win', 'yes', 'on'].includes(ls)) return true;
       }
     } catch {}
     return false;
+  });
+
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(location.search);
+      const v = (params.get('demo') || '').toLowerCase();
+      if (['1', 'true', 'win', 'yes', 'on'].includes(v)) setDemoMode(true);
+      else if (['0', 'false', 'off', 'no'].includes(v)) setDemoMode(false);
+    } catch {}
   }, [location.search]);
+
+  useEffect(() => {
+    try {
+      if (typeof window !== 'undefined') {
+        if (demoMode) window.localStorage.setItem('STACKMATE_DEMO_WIN_FIRST', '1');
+        else window.localStorage.removeItem('STACKMATE_DEMO_WIN_FIRST');
+      }
+    } catch {}
+  }, [demoMode]);
   const [penalties, setPenalties] = useState(0);
 
   const [game, setGame] = useState<Chess | null>(() => {
@@ -493,6 +511,13 @@ export default function SolvePuzzle() {
                   {showDemoBadge && (
                     <NeoBadge color={colors.accent} size="lg">DEMO MODE</NeoBadge>
                   )}
+                  <NeoButton
+                    variant={demoMode ? 'accent' : 'secondary'}
+                    size="sm"
+                    onClick={() => setDemoMode((v) => !v)}
+                  >
+                    {demoMode ? 'DEMO ON' : 'DEMO OFF'}
+                  </NeoButton>
                   <div
                     style={{
                       padding: '12px 20px',


### PR DESCRIPTION
## Add Demo Mode Toggle on Solve Page

### What
Adds a small UI toggle to enable/disable Demo Mode directly on the Solve page — no need for URL parameters.

### How it works
- Toggle button labeled `DEMO ON` / `DEMO OFF` beside the puzzle badge
- Persists to localStorage key: `STACKMATE_DEMO_WIN_FIRST`
- Query param `?demo=1/0` still supported and can override

### Why
For quick demos without editing the URL. When ON, the first correct move immediately shows the win modal (and blockchain submission is skipped).

### Safety
- Demo mode only affects client behavior on the Solve page
- Normal flow unaffected when OFF

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ec798605-ebab-4ed5-b942-fa7d173f63f3/task/2696ffac-5942-491c-82e7-5b25bc1d0aba))