### PR TITLE
Demo mode: show win modal after first user move (any legal move)

### DIFF
--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -308,6 +308,20 @@ export default function SolvePuzzle() {
       return;
     }
 
+    // DEMO: show win modal immediately after the first user move (any legal move)
+    if (demoMode) {
+      const san = made.san;
+      setGame(g);
+      setBoardFen(g.fen());
+      setHistory((h) => [...h, san]);
+      setLastMove({ from: from as Square, to: to as Square });
+      setHintMove(null);
+      setIndex(index + 1);
+      setSolved(true);
+      submittedRef.current = true; // prevent blockchain submission in demo
+      return;
+    }
+
     const san = made.san;
     const normalize = (s: string) => s.replace(/[+#]+$/g, '');
     const ok = normalize(san) === normalize(expected);
@@ -319,19 +333,6 @@ export default function SolvePuzzle() {
       if (newAttempts >= 3) {
         setFailed(true);
       }
-      return;
-    }
-
-    // DEMO: show win modal immediately after the first correct move
-    if (demoMode) {
-      setGame(g);
-      setBoardFen(g.fen());
-      setHistory((h) => [...h, san]);
-      setLastMove({ from: from as Square, to: to as Square });
-      setHintMove(null);
-      setIndex(index + 1);
-      setSolved(true);
-      submittedRef.current = true; // prevent blockchain submission in demo
       return;
     }
 


### PR DESCRIPTION
## Demo Mode: Win After First User Move (Any Legal Move)

### What changed
- In Demo Mode, the app now shows the "Solved!" modal immediately after the first user move, regardless of whether it matches the exact expected SAN for the puzzle.
- This makes demo behavior reliable even if the presenter plays a different legal move.

### Why
- Earlier, Demo Mode required the first move to be the exact expected solution move; that could be confusing during live demos.

### Details
- The demo check runs immediately after a legal move is made and before correctness validation.
- Still skips blockchain submission while demo is active.

### Safety
- Only affects Demo Mode. Normal gameplay remains unchanged when demo is OFF.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ec798605-ebab-4ed5-b942-fa7d173f63f3/task/2696ffac-5942-491c-82e7-5b25bc1d0aba))