### PR TITLE
Fix demo mode: skip entry requirement to allow modal to show

### DIFF
--- a/src/pages/SolvePuzzle.tsx
+++ b/src/pages/SolvePuzzle.tsx
@@ -252,10 +252,11 @@ export default function SolvePuzzle() {
 
   useEffect(() => {
     if (loading) return;
+    if (demoMode) return; // Allow demo mode without entry
     if (!entered) {
       navigate('/', { replace: true });
     }
-  }, [loading, entered]);
+  }, [loading, entered, demoMode]);
 
   const nextExpectedSan = useMemo(() => localPuzzle?.solution[index] ?? null, [localPuzzle?.solution, index]);
 
@@ -288,6 +289,7 @@ export default function SolvePuzzle() {
   }, [index, localPuzzle?.solution?.length]);
 
   const onMove = useCallback((from: string, to: string) => {
+    console.log('[SolvePuzzle] onMove called with demoMode:', demoMode, 'from:', from, 'to:', to);
     if (solved || failed || !game || !localPuzzle) return;
 
     const g = new Chess(game.fen());
@@ -310,6 +312,7 @@ export default function SolvePuzzle() {
 
     // DEMO: show win modal immediately after the first user move (any legal move)
     if (demoMode) {
+      console.log('[SolvePuzzle] DEMO MODE: Setting solved=true after first move');
       const san = made.san;
       setGame(g);
       setBoardFen(g.fen());
@@ -319,6 +322,7 @@ export default function SolvePuzzle() {
       setIndex(index + 1);
       setSolved(true);
       submittedRef.current = true; // prevent blockchain submission in demo
+      console.log('[SolvePuzzle] DEMO MODE: solved state set, should show modal');
       return;
     }
 


### PR DESCRIPTION
## Fix: Demo mode entry requirement blocking modal

### Critical Issue Fixed
Demo Mode was redirecting users to home if they hadn't entered the puzzle (paid entry fee). This prevented the win modal from ever appearing in demo.

### Solution
Skip the `!entered` redirect check when `demoMode` is active.

### Changes
- `src/pages/SolvePuzzle.tsx`
  - Added `demoMode` check to entry requirement useEffect
  - Added console.log debug statements to trace demo flow
  
### Result
- Demo Mode now works without requiring entry fee payment
- Win modal appears after first move when DEMO ON is toggled
- Normal gameplay still requires entry when demo is OFF

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ec798605-ebab-4ed5-b942-fa7d173f63f3/task/2696ffac-5942-491c-82e7-5b25bc1d0aba))